### PR TITLE
Remove bakery wrapping just targets

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,6 +1,5 @@
 #!/usr/bin/env just --justfile
 
-BAKERY_VERSION := "0.2.0.dev0"
 GITHUB_TOKEN := `gh auth token`
 
 install-bakery *OPTS:
@@ -25,21 +24,3 @@ download-pti:
       -H "Authorization: Bearer {{GITHUB_TOKEN}}" \
       https://api.github.com/repos/posit-dev/pti/releases/assets/220659328 \
       -o {{justfile_directory()}}/tools/pti
-
-new product *OPTS:
-  bakery new {{product}} --context {{ justfile_directory() }} *OPTS
-
-alias generate := render
-render product version r_version python_version *OPTS:
-  bakery render {{product}} {{version}} \
-    --value r_version={{r_version}} \
-    --value python_version={{python_version}} {{OPTS}}
-
-alias bake := build
-build *OPTS:
-  just download-pti
-  bakery build --context {{ justfile_directory() }} {{OPTS}}
-
-alias dgoss := test
-test *OPTS:
-  bakery dgoss --context {{ justfile_directory() }} {{OPTS}}


### PR DESCRIPTION
This started out as removing a reference to the old `posit/base` image, but after some thinking I lean towards removing these wrappers. If `bakery` isn't easy enough to use directly, we should fix `bakery` instead of wrapping it. I created https://github.com/posit-dev/images-shared/issues/112 to help improve the behavior gap that the Justfile aided in bridging.