### PR TITLE
Remove `--platform` option from `FROM` header in PPM

### DIFF
--- a/package-manager/2024.04/Containerfile.ubuntu2204.min
+++ b/package-manager/2024.04/Containerfile.ubuntu2204.min
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 docker.io/library/ubuntu:22.04
+FROM docker.io/library/ubuntu:22.04
 LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:22.04"
 
 ### ARG declarations ###

--- a/package-manager/2024.04/Containerfile.ubuntu2204.std
+++ b/package-manager/2024.04/Containerfile.ubuntu2204.std
@@ -1,14 +1,12 @@
 # Build Python using uv in a separate stage
 FROM ghcr.io/astral-sh/uv:bookworm-slim AS python-builder
+
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
-
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
-
 ENV UV_PYTHON_PREFERENCE=only-managed
-
 RUN uv python install 3.12.1
 
-FROM --platform=linux/amd64 docker.io/library/ubuntu:22.04
+FROM docker.io/library/ubuntu:22.04
 LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:22.04"
 
 ### ARG declarations ###

--- a/package-manager/2024.08/Containerfile.ubuntu2204.min
+++ b/package-manager/2024.08/Containerfile.ubuntu2204.min
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 docker.io/library/ubuntu:22.04
+FROM docker.io/library/ubuntu:22.04
 LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:22.04"
 
 ### ARG declarations ###

--- a/package-manager/2024.08/Containerfile.ubuntu2204.std
+++ b/package-manager/2024.08/Containerfile.ubuntu2204.std
@@ -1,14 +1,12 @@
 # Build Python using uv in a separate stage
 FROM ghcr.io/astral-sh/uv:bookworm-slim AS python-builder
+
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
-
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
-
 ENV UV_PYTHON_PREFERENCE=only-managed
-
 RUN uv python install 3.12.6
 
-FROM --platform=linux/amd64 docker.io/library/ubuntu:22.04
+FROM docker.io/library/ubuntu:22.04
 LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:22.04"
 
 ### ARG declarations ###

--- a/package-manager/2024.11/Containerfile.ubuntu2204.min
+++ b/package-manager/2024.11/Containerfile.ubuntu2204.min
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 docker.io/library/ubuntu:22.04
+FROM docker.io/library/ubuntu:22.04
 LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:22.04"
 
 ### ARG declarations ###

--- a/package-manager/2024.11/Containerfile.ubuntu2204.std
+++ b/package-manager/2024.11/Containerfile.ubuntu2204.std
@@ -1,14 +1,12 @@
 # Build Python using uv in a separate stage
 FROM ghcr.io/astral-sh/uv:bookworm-slim AS python-builder
+
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
-
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
-
 ENV UV_PYTHON_PREFERENCE=only-managed
-
 RUN uv python install 3.12.8
 
-FROM --platform=linux/amd64 docker.io/library/ubuntu:22.04
+FROM docker.io/library/ubuntu:22.04
 LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:22.04"
 
 ### ARG declarations ###

--- a/package-manager/2025.04/Containerfile.ubuntu2204.min
+++ b/package-manager/2025.04/Containerfile.ubuntu2204.min
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 docker.io/library/ubuntu:22.04
+FROM docker.io/library/ubuntu:22.04
 LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:22.04"
 
 ### ARG declarations ###

--- a/package-manager/2025.04/Containerfile.ubuntu2204.std
+++ b/package-manager/2025.04/Containerfile.ubuntu2204.std
@@ -1,14 +1,12 @@
 # Build Python using uv in a separate stage
 FROM ghcr.io/astral-sh/uv:bookworm-slim AS python-builder
+
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
-
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
-
 ENV UV_PYTHON_PREFERENCE=only-managed
-
 RUN uv python install 3.12.11
 
-FROM --platform=linux/amd64 docker.io/library/ubuntu:22.04
+FROM docker.io/library/ubuntu:22.04
 LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:22.04"
 
 ### ARG declarations ###

--- a/package-manager/2025.09/Containerfile.ubuntu2204.min
+++ b/package-manager/2025.09/Containerfile.ubuntu2204.min
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 docker.io/library/ubuntu:22.04
+FROM docker.io/library/ubuntu:22.04
 LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:22.04"
 
 ### ARG declarations ###

--- a/package-manager/2025.09/Containerfile.ubuntu2204.std
+++ b/package-manager/2025.09/Containerfile.ubuntu2204.std
@@ -6,7 +6,7 @@ ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
 RUN uv python install 3.13.7
 
-FROM --platform=linux/amd64 docker.io/library/ubuntu:22.04
+FROM docker.io/library/ubuntu:22.04
 LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:22.04"
 
 ### ARG declarations ###

--- a/package-manager/template/Containerfile.ubuntu2204.jinja2
+++ b/package-manager/template/Containerfile.ubuntu2204.jinja2
@@ -12,7 +12,7 @@ Bakery handles bootstrapping the files into template rendering.
 
 {% endif -%}
 
-FROM --platform=linux/amd64 docker.io/library/ubuntu:22.04
+FROM docker.io/library/ubuntu:22.04
 LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:22.04"
 
 ### ARG declarations ###


### PR DESCRIPTION
Since `bakery` implicitly adds this, it should be removable. We may want to add a note somewhere for building directly to use `--platform linux/amd64`.