### PR TITLE
Add Slack build notifications to CI workflows

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -29,8 +29,14 @@ jobs:
       - dev
     steps:
       - uses: re-actors/alls-green@release/v1
+        id: alls-green
         with:
           jobs: ${{ toJSON(needs) }}
+      - if: always() && github.ref == 'refs/heads/main'
+        uses: posit-dev/images-shared/.github/actions/slack-build-notify@main
+        with:
+          result: ${{ steps.alls-green.outcome }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   dev:
     name: Build

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           jobs: ${{ toJSON(needs) }}
       - if: always() && github.ref == 'refs/heads/main'
+        continue-on-error: true
         uses: posit-dev/images-shared/.github/actions/slack-build-notify@main
         with:
           result: ${{ steps.alls-green.outcome }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -27,8 +27,14 @@ jobs:
       - build
     steps:
       - uses: re-actors/alls-green@release/v1
+        id: alls-green
         with:
           jobs: ${{ toJSON(needs) }}
+      - if: always() && github.ref == 'refs/heads/main'
+        uses: posit-dev/images-shared/.github/actions/slack-build-notify@main
+        with:
+          result: ${{ steps.alls-green.outcome }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   build:
     name: Build

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           jobs: ${{ toJSON(needs) }}
       - if: always() && github.ref == 'refs/heads/main'
+        continue-on-error: true
         uses: posit-dev/images-shared/.github/actions/slack-build-notify@main
         with:
           result: ${{ steps.alls-green.outcome }}


### PR DESCRIPTION
## Summary

- Add Slack notification step to CI meta-jobs in `development.yml` and `production.yml`
- Uses the `slack-build-notify` composite action from posit-dev/images-shared#432

Notifications fire on state transitions only (passing->failing, failing->passing) and include failed job/step details with links.

### Before merge

- [ ] Merge posit-dev/images-shared#432 first
- [ ] Revert action ref from `@worktree-slack-build-notify` to `@main`
- [ ] Add `SLACK_WEBHOOK_URL` repo secret pointing at `#platform-builds-images`

## Test plan

- [ ] Verify notification fires after merge to main
- [ ] Verify no notification on unchanged state