### PR TITLE
Scope clean jobs to match build version filters

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -67,6 +67,7 @@ jobs:
 
     uses: "posit-dev/images-shared/.github/workflows/clean.yml@main"
     with:
+      dev-versions: "only"
       remove-dangling-caches: true
       remove-caches-older-than: 14
       remove-dangling-temporary-images: false


### PR DESCRIPTION
## Summary

- Development clean passes `dev-versions: "only"`
- Production clean uses defaults (exclude both)

Depends on posit-dev/images-shared#438

## Test plan

- [ ] Development workflow cleanup removes dev image caches