### PR TITLE
Add fork-safe PR workflow and permissions

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -20,6 +20,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 concurrency:
   # Only cancel in-progress runs for pull_request events, this prevents cancelling workflows against main or tags
   # A pull_request will reuse the same group thus enabling cancelation, all others receive a unique run_id
@@ -32,6 +34,7 @@ jobs:
     # Use this job for branch protection status checks.
     if: always()
     runs-on: ubuntu-latest
+    permissions: {}
     needs:
       - dev
     steps:

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -16,8 +16,6 @@ on:
     # Hourly rebuild of dev images
     - cron: "45 * * * *" # At minute 45 past every hour
 
-  pull_request:
-
   push:
     branches:
       - main

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -37,7 +37,7 @@ jobs:
     needs:
       - dev
     steps:
-      - uses: re-actors/alls-green@release/v1
+      - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # v1.2.2
         id: alls-green
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -22,8 +22,6 @@ on:
 
 
 concurrency:
-  # Only cancel in-progress runs for pull_request events, this prevents cancelling workflows against main or tags
-  # A pull_request will reuse the same group thus enabling cancelation, all others receive a unique run_id
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -20,7 +20,6 @@ on:
     branches:
       - main
 
-permissions: {}
 
 concurrency:
   # Only cancel in-progress runs for pull_request events, this prevents cancelling workflows against main or tags

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -28,8 +28,8 @@ jobs:
           project-url: https://github.com/orgs/posit-dev/projects/17
 
       - name: Add Default Labels
-        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf  # v1.1.3
-        with:
-          github_token: ${{ steps.app-token.outputs.token }}
-          labels: |
-            docker
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: gh issue edit "$ISSUE_NUMBER" --add-label "docker"

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -15,20 +15,20 @@ jobs:
     steps:
 
       - name: GitHub App Token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3.0.0
         id: app-token
         with:
           app-id: ${{ secrets.PPM_AUTOMATION_APP_ID }}
           private-key: ${{ secrets.PPM_AUTOMATION_PEM }}
 
       - name: Add to Platform Carbon Project
-        uses: actions/add-to-project@v1.0.2
+        uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e  # v1.0.2
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           project-url: https://github.com/orgs/posit-dev/projects/17
 
       - name: Add Default Labels
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf  # v1.1.3
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           labels: |

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -4,11 +4,14 @@ on:
     types:
       - opened
 
+permissions: {}
+
 jobs:
   issue:
     # only run in posit-dev/images-package-manager.
     if: github.repository == 'posit-dev/images-package-manager'
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
 
       - name: GitHub App Token

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,6 @@ name: Pull Request
 on:
   pull_request:
 
-permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,7 +18,7 @@ jobs:
       - production
       - development
     steps:
-      - uses: re-actors/alls-green@release/v1
+      - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,42 @@
+name: Pull Request
+on:
+  pull_request:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: CI
+    if: always()
+    runs-on: ubuntu-latest
+    permissions: {}
+    timeout-minutes: 10
+    needs:
+      - production
+      - development
+    steps:
+      - uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}
+
+  production:
+    name: Production
+    permissions:
+      contents: read
+      packages: write
+    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
+    with:
+      dev-versions: "exclude"
+
+  development:
+    name: Development
+    permissions:
+      contents: read
+      packages: write
+    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
+    with:
+      dev-versions: "only"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,7 +27,7 @@ jobs:
     name: Production
     permissions:
       contents: read
-      packages: write
+      packages: read
     uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
     with:
       dev-versions: "exclude"
@@ -36,7 +36,7 @@ jobs:
     name: Development
     permissions:
       contents: read
-      packages: write
+      packages: read
     uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
     with:
       dev-versions: "only"
@@ -46,6 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,6 +17,7 @@ jobs:
     needs:
       - production
       - development
+      - zizmor
     steps:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # v1.2.2
         with:
@@ -39,3 +40,14 @@ jobs:
     uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
     with:
       dev-versions: "only"
+
+  zizmor:
+    name: Zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8  # v0.5.2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,7 +27,7 @@ jobs:
     name: Production
     permissions:
       contents: read
-      packages: read
+      packages: write
     uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
     with:
       dev-versions: "exclude"
@@ -36,7 +36,7 @@ jobs:
     name: Development
     permissions:
       contents: read
-      packages: read
+      packages: write
     uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
     with:
       dev-versions: "only"

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -7,8 +7,6 @@ on:
     # Weekly rebuild of all images, to pick up any upstream changes.
     - cron: "15 3 * * 0" # At 03:15 on Sunday
 
-  pull_request:
-
   push:
     branches:
       - main

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -11,7 +11,6 @@ on:
     branches:
       - main
 
-permissions: {}
 
 concurrency:
   # Only cancel in-progress runs for pull_request events, this prevents cancelling workflows against main or tags

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -29,7 +29,7 @@ jobs:
       - lint
       - build
     steps:
-      - uses: re-actors/alls-green@release/v1
+      - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # v1.2.2
         id: alls-green
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -11,6 +11,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 concurrency:
   # Only cancel in-progress runs for pull_request events, this prevents cancelling workflows against main or tags
   # A pull_request will reuse the same group thus enabling cancelation, all others receive a unique run_id
@@ -23,6 +25,7 @@ jobs:
     # Use this job for branch protection status checks.
     if: always()
     runs-on: ubuntu-latest
+    permissions: {}
     needs:
       - lint
       - build

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -13,8 +13,6 @@ on:
 
 
 concurrency:
-  # Only cancel in-progress runs for pull_request events, this prevents cancelling workflows against main or tags
-  # A pull_request will reuse the same group thus enabling cancelation, all others receive a unique run_id
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Release
+
 on:
   workflow_dispatch:
     inputs:
@@ -6,6 +7,8 @@ on:
         description: "Product version (e.g. 2026.01.0-15)"
         required: true
         type: string
+
+permissions: {}
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,6 @@ on:
         required: true
         type: string
 
-permissions: {}
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ on:
 
 jobs:
   release:
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
     uses: posit-dev/images-shared/.github/workflows/product-release.yml@main
     with:
       version: ${{ inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   release:
+    if: github.event_name == 'workflow_dispatch'
     timeout-minutes: 10
     permissions:
       contents: write

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,9 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # Shared workflows and composite actions from images-shared
+        # are kept at @main intentionally.
+        "posit-dev/images-shared/*": ref-pin
+        "*": hash-pin
+


### PR DESCRIPTION
## Summary

- Add `pr.yml` calling `bakery-build-pr.yml@main` for fork-safe PR builds
- Remove `pull_request` trigger from existing build workflows (handled by `pr.yml`)
- Add `permissions: {}` at workflow level + per-job declarations

Part of rstudio/platform-team#435.

## Test plan

- [ ] `pr.yml` runs on this PR
- [ ] Existing build workflows do not trigger on PRs
- [ ] Push-to-main and schedule triggers still work after merge