### PR TITLE
Add dispatch inputs to development workflow

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -2,6 +2,15 @@ name: Development
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Product version to build (e.g. 2026.04.0)"
+        required: false
+        type: string
+      stream:
+        description: "Dev stream to build (e.g. 'daily', 'preview')"
+        required: false
+        type: string
 
   schedule:
     # Hourly rebuild of dev images
@@ -53,7 +62,9 @@ jobs:
     uses: "posit-dev/images-shared/.github/workflows/bakery-build-native.yml@main"
     with:
       dev-versions: "only"
-      # Push images only for merges into main and hourly schduled re-builds.
+      image-version: ${{ inputs.version }}
+      dev-stream: ${{ inputs.stream }}
+      # Push on merges to main, scheduled rebuilds, and dispatches targeting main.
       push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
 
   clean:


### PR DESCRIPTION
## Summary

- Add `version` and `stream` inputs to `workflow_dispatch` on `development.yml`
- Forward `version` as `image-version` and `stream` as `dev-stream` to the shared `bakery-build-native.yml` workflow (images-shared#480)
- Important for Package Manager which has both `daily` and `preview` dev streams — callers can now target a specific stream instead of rebuilding both

Part of posit-dev/images-shared#302. Requires images-shared#480 on main (merged).