### PR TITLE
Remove dead GITHUB_TOKEN assignment from justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,7 +1,5 @@
 #!/usr/bin/env just --justfile
 
-GITHUB_TOKEN := `gh auth token`
-
 install-bakery *OPTS:
   #!/bin/bash
   # TODO: Update this after package is published somewhere


### PR DESCRIPTION
## Summary

Delete the top-level `GITHUB_TOKEN` assignment in `justfile`:

```just
GITHUB_TOKEN := `gh auth token`
```

It's not referenced by any recipe — pure dead code.

## Why

The top-level assignment runs `gh auth token` at justfile load time on every `just` invocation. That meant every recipe in this repo — even `install-goss`, which has nothing to do with GitHub — failed to parse unless `gh` was installed and authenticated. It's an implicit prerequisite not listed in the README.

After this change, `gh` is no longer required to run any justfile recipe.

## Test plan

- [x] `just --list` succeeds without `gh` installed/authenticated
- [x] `just install-goss` still works (unchanged)
- [x] `just install-bakery` still works (unchanged)