### PR TITLE
Use PPM_AUTOMATION secrets for app token

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -15,8 +15,8 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.PPM_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.PPM_AUTOMATION_PEM }}
 
       - name: Add to Platform Carbon Project
         uses: actions/add-to-project@v1.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,5 +14,5 @@ jobs:
       version: ${{ inputs.version }}
       images: "package-manager"
     secrets:
-      APP_ID: ${{ secrets.APP_ID }}
-      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      APP_ID: ${{ secrets.PPM_AUTOMATION_APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.PPM_AUTOMATION_PEM }}


### PR DESCRIPTION
## Summary

Replace the generic `APP_ID` / `APP_PRIVATE_KEY` secrets with the app-specific
`PPM_AUTOMATION_APP_ID` / `PPM_AUTOMATION_PEM` secrets provisioned by
[rstudio/github-iac](https://github.com/rstudio/github-iac).

- `issues.yml`: direct `actions/create-github-app-token` caller — update both sides.
- `release.yml`: passthrough into `posit-dev/images-shared`'s `product-release.yml`
  reusable — update only the right-hand side of the `secrets:` block; the
  reusable's `APP_ID` / `APP_PRIVATE_KEY` input names are kept.

## Test plan

- [ ] Trigger the issue automation workflow (open a test issue) and confirm the run still succeeds
- [ ] Run the release workflow and confirm the token-issuance step succeeds