### PR TITLE
Add Ubuntu 26.04 support

### DIFF
--- a/bakery.yaml
+++ b/bakery.yaml
@@ -45,6 +45,10 @@ images:
         product: "package-manager"
         stream: "preview"
         os:
+          - name: Ubuntu 26.04
+            platforms:
+              - linux/amd64
+              - linux/arm64
           - name: Ubuntu 24.04
             primary: true
             platforms:
@@ -59,6 +63,10 @@ images:
         product: "package-manager"
         stream: "daily"
         os:
+          - name: Ubuntu 26.04
+            platforms:
+              - linux/amd64
+              - linux/arm64
           - name: Ubuntu 24.04
             primary: true
             platforms:
@@ -92,6 +100,10 @@ images:
             platforms:
               - linux/amd64
               - linux/arm64
+          - name: Ubuntu 26.04
+            platforms:
+              - linux/amd64
+              - linux/arm64
         dependencies:
           - dependency: R
             version: 4.6.1
@@ -106,6 +118,10 @@ images:
             platforms:
               - linux/amd64
               - linux/arm64
+          - name: Ubuntu 26.04
+            platforms:
+              - linux/amd64
+              - linux/arm64
         dependencies:
           - dependency: R
             version: 4.6.0
@@ -117,6 +133,10 @@ images:
           - name: Ubuntu 22.04
           - name: Ubuntu 24.04
             primary: true
+            platforms:
+              - linux/amd64
+              - linux/arm64
+          - name: Ubuntu 26.04
             platforms:
               - linux/amd64
               - linux/arm64

--- a/package-manager/2026.04/Containerfile.ubuntu2604.min
+++ b/package-manager/2026.04/Containerfile.ubuntu2604.min
@@ -1,0 +1,60 @@
+FROM docker.io/library/ubuntu:26.04
+LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:26.04"
+
+### ARG declarations ###
+ARG TARGETARCH
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV PPM_LICENSE=""
+ENV PPM_LICENSE_SERVER=""
+ENV PPM_LICENSE_FILE_PATH=""
+ENV PPM_STARTUP_DEBUG=0
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+### Setup environment ###
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
+    apt-get upgrade -yqq && \
+    apt-get dist-upgrade -yqq && \
+    apt-get autoremove -yqq --purge && \
+    apt-get install -yqq --no-install-recommends \
+        curl \
+        ca-certificates \
+        gnupg \
+        tar && \
+    bash -c "$(curl -1fsSL 'https://dl.posit.co/public/pro/setup.deb.sh')" && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
+
+### Install Apt Packages ###
+COPY package-manager/2026.04/deps/ubuntu-26.04_packages.txt /tmp/packages.txt
+RUN apt-get update -yqq && \
+    xargs -a /tmp/packages.txt apt-get install -yqq --no-install-recommends && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
+
+
+
+### Install Package Manager 2026.04.2 ###
+ARG PACKAGE_MANAGER_VERSION="2026.04.2"
+COPY --chmod=0755 package-manager/2026.04/scripts/install_package_manager.sh /tmp/install_package_manager.sh
+RUN \
+    /tmp/install_package_manager.sh \
+    && rm -f /tmp/install_package_manager.sh
+
+### Add startup.sh script ###
+COPY --chmod=0775 package-manager/2026.04/scripts/startup.sh /usr/local/bin/startup.sh
+RUN mkdir -p /var/run/rstudio-pm \
+    && chmod +x /usr/local/bin/startup.sh \
+    && chown rstudio-pm:rstudio-pm /usr/local/bin/startup.sh \
+    && chown -R rstudio-pm:rstudio-pm /var/run/rstudio-pm
+
+USER rstudio-pm
+
+RUN echo "source <(rspm completion bash)" >> ~/.bashrc
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD curl -fsS http://localhost:4242/__ping__ || exit 1
+
+CMD ["/usr/local/bin/startup.sh"]

--- a/package-manager/2026.04/Containerfile.ubuntu2604.std
+++ b/package-manager/2026.04/Containerfile.ubuntu2604.std
@@ -1,0 +1,81 @@
+# Build Python using uv in a separate stage
+FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
+
+ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
+ENV UV_PYTHON_INSTALL_DIR=/opt/python
+ENV UV_PYTHON_PREFERENCE=only-managed
+RUN uv python install 3.14.4
+RUN mv /opt/python/cpython-3.14.4-linux-*/ /opt/python/3.14.4
+
+
+FROM docker.io/library/ubuntu:26.04
+LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:26.04"
+
+### ARG declarations ###
+ARG TARGETARCH
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV PPM_LICENSE=""
+ENV PPM_LICENSE_SERVER=""
+ENV PPM_LICENSE_FILE_PATH=""
+ENV PPM_STARTUP_DEBUG=0
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+### Setup environment ###
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
+    apt-get upgrade -yqq && \
+    apt-get dist-upgrade -yqq && \
+    apt-get autoremove -yqq --purge && \
+    apt-get install -yqq --no-install-recommends \
+        curl \
+        ca-certificates \
+        gnupg \
+        tar && \
+    bash -c "$(curl -1fsSL 'https://dl.posit.co/public/pro/setup.deb.sh')" && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
+
+### Install Apt Packages ###
+COPY package-manager/2026.04/deps/ubuntu-26.04_packages.txt /tmp/packages.txt
+RUN apt-get update -yqq && \
+    xargs -a /tmp/packages.txt apt-get install -yqq --no-install-recommends && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
+
+### Install Python from previous stage ###
+COPY --from=python-builder /opt/python /opt/python
+
+### Install Python packages ###
+COPY package-manager/2026.04/deps/python_requirements.txt /tmp/requirements.txt
+RUN /opt/python/3.14.4/bin/pip install --no-cache-dir --upgrade --break-system-packages \
+        -r /tmp/requirements.txt && \
+    rm -f /tmp/requirements.txt
+
+### Install R ###
+RUN RUN_UNATTENDED=1 R_VERSION=4.5.3 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \
+    find . -type f -name '[rR]-4.5.3.*\.(deb|rpm)' -delete
+
+### Install Package Manager 2026.04.2 ###
+ARG PACKAGE_MANAGER_VERSION="2026.04.2"
+COPY --chmod=0755 package-manager/2026.04/scripts/install_package_manager.sh /tmp/install_package_manager.sh
+RUN PYTHON_VERSION=3.14.4 R_VERSION=4.5.3 \
+    /tmp/install_package_manager.sh \
+    && rm -f /tmp/install_package_manager.sh
+
+### Add startup.sh script ###
+COPY --chmod=0775 package-manager/2026.04/scripts/startup.sh /usr/local/bin/startup.sh
+RUN mkdir -p /var/run/rstudio-pm \
+    && chmod +x /usr/local/bin/startup.sh \
+    && chown rstudio-pm:rstudio-pm /usr/local/bin/startup.sh \
+    && chown -R rstudio-pm:rstudio-pm /var/run/rstudio-pm
+
+USER rstudio-pm
+
+RUN echo "source <(rspm completion bash)" >> ~/.bashrc
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD curl -fsS http://localhost:4242/__ping__ || exit 1
+
+CMD ["/usr/local/bin/startup.sh"]

--- a/package-manager/2026.04/deps/ubuntu-26.04_packages.txt
+++ b/package-manager/2026.04/deps/ubuntu-26.04_packages.txt
@@ -1,0 +1,2 @@
+libc6
+openssl

--- a/package-manager/2026.05/Containerfile.ubuntu2604.min
+++ b/package-manager/2026.05/Containerfile.ubuntu2604.min
@@ -1,0 +1,60 @@
+FROM docker.io/library/ubuntu:26.04
+LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:26.04"
+
+### ARG declarations ###
+ARG TARGETARCH
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV PPM_LICENSE=""
+ENV PPM_LICENSE_SERVER=""
+ENV PPM_LICENSE_FILE_PATH=""
+ENV PPM_STARTUP_DEBUG=0
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+### Setup environment ###
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
+    apt-get upgrade -yqq && \
+    apt-get dist-upgrade -yqq && \
+    apt-get autoremove -yqq --purge && \
+    apt-get install -yqq --no-install-recommends \
+        curl \
+        ca-certificates \
+        gnupg \
+        tar && \
+    bash -c "$(curl -1fsSL 'https://dl.posit.co/public/pro/setup.deb.sh')" && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
+
+### Install Apt Packages ###
+COPY package-manager/2026.05/deps/ubuntu-26.04_packages.txt /tmp/packages.txt
+RUN apt-get update -yqq && \
+    xargs -a /tmp/packages.txt apt-get install -yqq --no-install-recommends && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
+
+
+
+### Install Package Manager 2026.05.0 ###
+ARG PACKAGE_MANAGER_VERSION="2026.05.0"
+COPY --chmod=0755 package-manager/2026.05/scripts/install_package_manager.sh /tmp/install_package_manager.sh
+RUN \
+    /tmp/install_package_manager.sh \
+    && rm -f /tmp/install_package_manager.sh
+
+### Add startup.sh script ###
+COPY --chmod=0775 package-manager/2026.05/scripts/startup.sh /usr/local/bin/startup.sh
+RUN mkdir -p /var/run/rstudio-pm \
+    && chmod +x /usr/local/bin/startup.sh \
+    && chown rstudio-pm:rstudio-pm /usr/local/bin/startup.sh \
+    && chown -R rstudio-pm:rstudio-pm /var/run/rstudio-pm
+
+USER rstudio-pm
+
+RUN echo "source <(rspm completion bash)" >> ~/.bashrc
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD curl -fsS http://localhost:4242/__ping__ || exit 1
+
+CMD ["/usr/local/bin/startup.sh"]

--- a/package-manager/2026.05/Containerfile.ubuntu2604.std
+++ b/package-manager/2026.05/Containerfile.ubuntu2604.std
@@ -1,0 +1,81 @@
+# Build Python using uv in a separate stage
+FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
+
+ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
+ENV UV_PYTHON_INSTALL_DIR=/opt/python
+ENV UV_PYTHON_PREFERENCE=only-managed
+RUN uv python install 3.14.5
+RUN mv /opt/python/cpython-3.14.5-linux-*/ /opt/python/3.14.5
+
+
+FROM docker.io/library/ubuntu:26.04
+LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:26.04"
+
+### ARG declarations ###
+ARG TARGETARCH
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV PPM_LICENSE=""
+ENV PPM_LICENSE_SERVER=""
+ENV PPM_LICENSE_FILE_PATH=""
+ENV PPM_STARTUP_DEBUG=0
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+### Setup environment ###
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
+    apt-get upgrade -yqq && \
+    apt-get dist-upgrade -yqq && \
+    apt-get autoremove -yqq --purge && \
+    apt-get install -yqq --no-install-recommends \
+        curl \
+        ca-certificates \
+        gnupg \
+        tar && \
+    bash -c "$(curl -1fsSL 'https://dl.posit.co/public/pro/setup.deb.sh')" && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
+
+### Install Apt Packages ###
+COPY package-manager/2026.05/deps/ubuntu-26.04_packages.txt /tmp/packages.txt
+RUN apt-get update -yqq && \
+    xargs -a /tmp/packages.txt apt-get install -yqq --no-install-recommends && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
+
+### Install Python from previous stage ###
+COPY --from=python-builder /opt/python /opt/python
+
+### Install Python packages ###
+COPY package-manager/2026.05/deps/python_requirements.txt /tmp/requirements.txt
+RUN /opt/python/3.14.5/bin/pip install --no-cache-dir --upgrade --break-system-packages \
+        -r /tmp/requirements.txt && \
+    rm -f /tmp/requirements.txt
+
+### Install R ###
+RUN RUN_UNATTENDED=1 R_VERSION=4.6.0 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \
+    find . -type f -name '[rR]-4.6.0.*\.(deb|rpm)' -delete
+
+### Install Package Manager 2026.05.0 ###
+ARG PACKAGE_MANAGER_VERSION="2026.05.0"
+COPY --chmod=0755 package-manager/2026.05/scripts/install_package_manager.sh /tmp/install_package_manager.sh
+RUN PYTHON_VERSION=3.14.5 R_VERSION=4.6.0 \
+    /tmp/install_package_manager.sh \
+    && rm -f /tmp/install_package_manager.sh
+
+### Add startup.sh script ###
+COPY --chmod=0775 package-manager/2026.05/scripts/startup.sh /usr/local/bin/startup.sh
+RUN mkdir -p /var/run/rstudio-pm \
+    && chmod +x /usr/local/bin/startup.sh \
+    && chown rstudio-pm:rstudio-pm /usr/local/bin/startup.sh \
+    && chown -R rstudio-pm:rstudio-pm /var/run/rstudio-pm
+
+USER rstudio-pm
+
+RUN echo "source <(rspm completion bash)" >> ~/.bashrc
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD curl -fsS http://localhost:4242/__ping__ || exit 1
+
+CMD ["/usr/local/bin/startup.sh"]

--- a/package-manager/2026.05/deps/ubuntu-26.04_packages.txt
+++ b/package-manager/2026.05/deps/ubuntu-26.04_packages.txt
@@ -1,0 +1,2 @@
+libc6
+openssl

--- a/package-manager/2026.06/Containerfile.ubuntu2604.min
+++ b/package-manager/2026.06/Containerfile.ubuntu2604.min
@@ -1,0 +1,60 @@
+FROM docker.io/library/ubuntu:26.04
+LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:26.04"
+
+### ARG declarations ###
+ARG TARGETARCH
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV PPM_LICENSE=""
+ENV PPM_LICENSE_SERVER=""
+ENV PPM_LICENSE_FILE_PATH=""
+ENV PPM_STARTUP_DEBUG=0
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+### Setup environment ###
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
+    apt-get upgrade -yqq && \
+    apt-get dist-upgrade -yqq && \
+    apt-get autoremove -yqq --purge && \
+    apt-get install -yqq --no-install-recommends \
+        curl \
+        ca-certificates \
+        gnupg \
+        tar && \
+    bash -c "$(curl -1fsSL 'https://dl.posit.co/public/pro/setup.deb.sh')" && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
+
+### Install Apt Packages ###
+COPY package-manager/2026.06/deps/ubuntu-26.04_packages.txt /tmp/packages.txt
+RUN apt-get update -yqq && \
+    xargs -a /tmp/packages.txt apt-get install -yqq --no-install-recommends && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
+
+
+
+### Install Package Manager 2026.06.0 ###
+ARG PACKAGE_MANAGER_VERSION="2026.06.0"
+COPY --chmod=0755 package-manager/2026.06/scripts/install_package_manager.sh /tmp/install_package_manager.sh
+RUN \
+    /tmp/install_package_manager.sh \
+    && rm -f /tmp/install_package_manager.sh
+
+### Add startup.sh script ###
+COPY --chmod=0775 package-manager/2026.06/scripts/startup.sh /usr/local/bin/startup.sh
+RUN mkdir -p /var/run/rstudio-pm \
+    && chmod +x /usr/local/bin/startup.sh \
+    && chown rstudio-pm:rstudio-pm /usr/local/bin/startup.sh \
+    && chown -R rstudio-pm:rstudio-pm /var/run/rstudio-pm
+
+USER rstudio-pm
+
+RUN echo "source <(rspm completion bash)" >> ~/.bashrc
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD curl -fsS http://localhost:4242/__ping__ || exit 1
+
+CMD ["/usr/local/bin/startup.sh"]

--- a/package-manager/2026.06/Containerfile.ubuntu2604.std
+++ b/package-manager/2026.06/Containerfile.ubuntu2604.std
@@ -1,0 +1,81 @@
+# Build Python using uv in a separate stage
+FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
+
+ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
+ENV UV_PYTHON_INSTALL_DIR=/opt/python
+ENV UV_PYTHON_PREFERENCE=only-managed
+RUN uv python install 3.14.6
+RUN mv /opt/python/cpython-3.14.6-linux-*/ /opt/python/3.14.6
+
+
+FROM docker.io/library/ubuntu:26.04
+LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:26.04"
+
+### ARG declarations ###
+ARG TARGETARCH
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV PPM_LICENSE=""
+ENV PPM_LICENSE_SERVER=""
+ENV PPM_LICENSE_FILE_PATH=""
+ENV PPM_STARTUP_DEBUG=0
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+### Setup environment ###
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
+    apt-get upgrade -yqq && \
+    apt-get dist-upgrade -yqq && \
+    apt-get autoremove -yqq --purge && \
+    apt-get install -yqq --no-install-recommends \
+        curl \
+        ca-certificates \
+        gnupg \
+        tar && \
+    bash -c "$(curl -1fsSL 'https://dl.posit.co/public/pro/setup.deb.sh')" && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
+
+### Install Apt Packages ###
+COPY package-manager/2026.06/deps/ubuntu-26.04_packages.txt /tmp/packages.txt
+RUN apt-get update -yqq && \
+    xargs -a /tmp/packages.txt apt-get install -yqq --no-install-recommends && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
+
+### Install Python from previous stage ###
+COPY --from=python-builder /opt/python /opt/python
+
+### Install Python packages ###
+COPY package-manager/2026.06/deps/python_requirements.txt /tmp/requirements.txt
+RUN /opt/python/3.14.6/bin/pip install --no-cache-dir --upgrade --break-system-packages \
+        -r /tmp/requirements.txt && \
+    rm -f /tmp/requirements.txt
+
+### Install R ###
+RUN RUN_UNATTENDED=1 R_VERSION=4.6.1 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \
+    find . -type f -name '[rR]-4.6.1.*\.(deb|rpm)' -delete
+
+### Install Package Manager 2026.06.0 ###
+ARG PACKAGE_MANAGER_VERSION="2026.06.0"
+COPY --chmod=0755 package-manager/2026.06/scripts/install_package_manager.sh /tmp/install_package_manager.sh
+RUN PYTHON_VERSION=3.14.6 R_VERSION=4.6.1 \
+    /tmp/install_package_manager.sh \
+    && rm -f /tmp/install_package_manager.sh
+
+### Add startup.sh script ###
+COPY --chmod=0775 package-manager/2026.06/scripts/startup.sh /usr/local/bin/startup.sh
+RUN mkdir -p /var/run/rstudio-pm \
+    && chmod +x /usr/local/bin/startup.sh \
+    && chown rstudio-pm:rstudio-pm /usr/local/bin/startup.sh \
+    && chown -R rstudio-pm:rstudio-pm /var/run/rstudio-pm
+
+USER rstudio-pm
+
+RUN echo "source <(rspm completion bash)" >> ~/.bashrc
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD curl -fsS http://localhost:4242/__ping__ || exit 1
+
+CMD ["/usr/local/bin/startup.sh"]

--- a/package-manager/2026.06/deps/ubuntu-26.04_packages.txt
+++ b/package-manager/2026.06/deps/ubuntu-26.04_packages.txt
@@ -1,0 +1,2 @@
+libc6
+openssl

--- a/package-manager/template/Containerfile.ubuntu2604.jinja2
+++ b/package-manager/template/Containerfile.ubuntu2604.jinja2
@@ -1,0 +1,69 @@
+{#-
+Below are imports for Bakery's macros. If any are unneeded, they can be removed.
+Bakery handles bootstrapping the files into template rendering.
+-#}
+{%- import "apt.j2" as apt -%}
+{%- import "python.j2" as python -%}
+{%- import "r.j2" as r -%}
+
+{%- if Image.Variant != "Minimal" -%}
+# Build Python using uv in a separate stage
+{{ python.build_stage(Dependencies.python) }}
+
+{% endif -%}
+
+FROM docker.io/library/ubuntu:26.04
+LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:26.04"
+
+### ARG declarations ###
+ARG TARGETARCH
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV PPM_LICENSE=""
+ENV PPM_LICENSE_SERVER=""
+ENV PPM_LICENSE_FILE_PATH=""
+ENV PPM_STARTUP_DEBUG=0
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+### Setup environment ###
+{{ apt.run_setup() }}
+
+### Install Apt Packages ###
+COPY {{ Path.Version }}/deps/ubuntu-26.04_packages.txt /tmp/packages.txt
+{{ apt.run_install(files = '/tmp/packages.txt') }}
+
+{% if not Image.Variant == "Minimal" -%}
+### Install Python from previous stage ###
+{{ python.copy_from_build_stage() }}
+
+### Install Python packages ###
+COPY {{ Path.Version }}/deps/python_requirements.txt /tmp/requirements.txt
+{{ python.run_install_packages(Dependencies.python, requirements_file='/tmp/requirements.txt') }}
+
+### Install R ###
+{{ r.run_install(Dependencies.R) }}
+{%- endif %}
+
+### Install Package Manager {{ Image.Version }} ###
+ARG PACKAGE_MANAGER_VERSION="{{ Image.Version }}"
+COPY --chmod=0755 {{ Path.Version }}/scripts/install_package_manager.sh /tmp/install_package_manager.sh
+RUN {% if Image.Variant != "Minimal" %}PYTHON_VERSION={{ Dependencies.python.0 }} R_VERSION={{ Dependencies.R.0 }} {% endif %}{% if Image.DownloadURL is defined %}DOWNLOAD_URL="{{ Image.DownloadURL }}" {% endif %}\
+    /tmp/install_package_manager.sh \
+    && rm -f /tmp/install_package_manager.sh
+
+### Add startup.sh script ###
+COPY --chmod=0775 {{ Path.Version }}/scripts/startup.sh /usr/local/bin/startup.sh
+RUN mkdir -p /var/run/rstudio-pm \
+    && chmod +x /usr/local/bin/startup.sh \
+    && chown rstudio-pm:rstudio-pm /usr/local/bin/startup.sh \
+    && chown -R rstudio-pm:rstudio-pm /var/run/rstudio-pm
+
+USER rstudio-pm
+
+RUN echo "source <(rspm completion bash)" >> ~/.bashrc
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD curl -fsS http://localhost:4242/__ping__ || exit 1
+
+CMD ["/usr/local/bin/startup.sh"]

--- a/package-manager/template/deps/ubuntu-26.04_packages.txt.jinja2
+++ b/package-manager/template/deps/ubuntu-26.04_packages.txt.jinja2
@@ -1,0 +1,2 @@
+libc6
+openssl


### PR DESCRIPTION
## Summary

- Add Ubuntu 26.04 to `2026.05.0` release
- Add Ubuntu 26.04 (resolute) to both preview and daily dev version streams
- Create ``Containerfile.ubuntu2604.jinja2`` and ``ubuntu-26.04_packages.txt.jinja2`` using the aligned naming convention from the base branch

## Dependencies

- Requires posit-dev/images-shared#494 to be merged first
