### PR TITLE
Remove `preview` devVersion

### DIFF
--- a/bakery.yaml
+++ b/bakery.yaml
@@ -40,20 +40,6 @@ images:
     devVersions:
       - sourceType: "stream"
         product: "package-manager"
-        stream: "preview"
-        os:
-          - name: Ubuntu 24.04
-            primary: true
-            platforms:
-              - linux/amd64
-              - linux/arm64
-          - name: Ubuntu 22.04
-        overrideRegistries:
-          - host: "ghcr.io"
-            namespace: "posit-dev"
-            repository: "package-manager-preview"
-      - sourceType: "stream"
-        product: "package-manager"
         stream: "daily"
         os:
           - name: Ubuntu 24.04


### PR DESCRIPTION
PPM changed their versioning scheme, and the preview stream version will
sometimes conflict with the production release version. Remove the
stream to prevent clobbering of production images.
