### PR TITLE
Remove preview disclaimer from README

### DIFF
--- a/package-manager/README.md
+++ b/package-manager/README.md
@@ -16,9 +16,6 @@ This container image provides [Package Manager](https://docs.posit.co/rspm/), a 
 ![Docker Hub Pulls](https://img.shields.io/docker/pulls/posit/package-manager)
 ![Docker Image Size](https://img.shields.io/docker/image-size/posit/package-manager/latest)
 
-> [!NOTE]
-> These images are in preview as Posit migrates container images from <a href="https://github.com/rstudio/rstudio-docker-products">rstudio/rstudio-docker-products</a>. The previous images remain supported.
-
 > [!TIP]
 > Deploying on Kubernetes? Try the <a href="https://docs.posit.co/helm/charts/rstudio-pm/README.html">Posit Package Manager Helm chart</a>!
 


### PR DESCRIPTION
## Summary

- Remove the "in preview" callout from `package-manager/README.md` now that the Posit container images are generally available.
- Fix the Posit Community Forum link to point at the canonical Package Manager subcategory (`/c/posit-professional-hosted/package-manager/21`) instead of the parent category (folded in from #86, now closed).

Refs posit-dev/images-shared#329.