### PR TITLE
Switch dev cron from hourly to daily at 04:45 UTC

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -13,8 +13,10 @@ on:
         type: string
 
   schedule:
-    # Hourly rebuild of dev images
-    - cron: "45 * * * *" # At minute 45 past every hour
+    # Daily rebuild of dev images. Staggered with images-connect (05:45) and
+    # images-workbench (06:45) so the three products don't all build in the
+    # same hour.
+    - cron: "45 4 * * *" # At 04:45 every day
 
   push:
     branches:


### PR DESCRIPTION
Cut development rebuilds from hourly to daily — dispatched builds from `rstudio/package-manager` already trigger fresh images on push, so the hourly fallback was over-eager.

Schedule at 04:45 UTC, one hour ahead of images-connect (05:45) and two hours ahead of images-workbench (06:45) so the three products don't share a build hour.

Part of posit-dev/images-shared#279.