### PR TITLE
Restagger crons: 01:15 prod, 07:45 daily

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -13,10 +13,11 @@ on:
         type: string
 
   schedule:
-    # Daily rebuild of dev images. Staggered with images-connect (05:45) and
-    # images-workbench (06:45) so the three products don't all build in the
-    # same hour.
-    - cron: "45 4 * * *" # At 04:45 every day
+    # Daily rebuild of dev images. Staggered with images-connect (08:45)
+    # and images-workbench (09:45) so the three products don't all build
+    # in the same hour. Weeklies run at 01–03 UTC, dailies at 07–09 UTC,
+    # with 04–06 UTC reserved as growth headroom.
+    - cron: "45 7 * * *" # At 07:45 every day
 
   push:
     branches:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -5,7 +5,10 @@ on:
 
   schedule:
     # Weekly rebuild of all images, to pick up any upstream changes.
-    - cron: "15 3 * * 0" # At 03:15 on Sunday
+    # Staggered with images-connect production (02:15 Sun) and
+    # images-workbench production (03:15 Sun) so the three products
+    # don't all build in the same hour.
+    - cron: "15 1 * * 0" # At 01:15 on Sunday
 
   push:
     branches:


### PR DESCRIPTION
Restagger this repo's crons into the wider weekly + daily schedule agreed across images-* (PPM/Connect/Workbench). PPM takes the first slot in both windows.

- `development.yml`: `45 4 * * *` → `45 7 * * *` (daily 04:45 → 07:45)
- `production.yml`: `15 3 * * 0` → `15 1 * * 0` (weekly 03:15 → 01:15)

Window layout:
- Weeklies at 01–03 UTC Sun
- 04–06 UTC reserved as growth headroom
- Dailies at 07–09 UTC

Follow-up to #89, which landed at 04:45 before the broader schedule was agreed.

Part of posit-dev/images-shared#279.