### PR TITLE
Funnel new-issue traffic to central Discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions and feedback
+    url: https://github.com/posit-dev/images/discussions
+    about: Ask questions and share your feedback with the team.


### PR DESCRIPTION
## Summary

Add `.github/ISSUE_TEMPLATE/config.yml` so the New Issue page surfaces a "Questions and feedback" contact link to the central [posit-dev/images Discussions](https://github.com/posit-dev/images/discussions).

`blank_issues_enabled` stays `true` so bug reports for this repo can still be filed against this repo's tracker — the contact link is a soft funnel for questions, not a hard redirect.