### PR TITLE
Configure apt retries in rendered Containerfiles

### DIFF
--- a/package-manager/2025.04/Containerfile.ubuntu2204.min
+++ b/package-manager/2025.04/Containerfile.ubuntu2204.min
@@ -13,7 +13,8 @@ ENV PPM_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/package-manager/2025.04/Containerfile.ubuntu2204.std
+++ b/package-manager/2025.04/Containerfile.ubuntu2204.std
@@ -23,7 +23,8 @@ ENV PPM_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/package-manager/2025.04/Containerfile.ubuntu2404.min
+++ b/package-manager/2025.04/Containerfile.ubuntu2404.min
@@ -14,7 +14,8 @@ ENV PPM_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/package-manager/2025.04/Containerfile.ubuntu2404.std
+++ b/package-manager/2025.04/Containerfile.ubuntu2404.std
@@ -24,7 +24,8 @@ ENV PPM_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/package-manager/2025.09/Containerfile.ubuntu2204.min
+++ b/package-manager/2025.09/Containerfile.ubuntu2204.min
@@ -13,7 +13,8 @@ ENV PPM_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/package-manager/2025.09/Containerfile.ubuntu2204.std
+++ b/package-manager/2025.09/Containerfile.ubuntu2204.std
@@ -23,7 +23,8 @@ ENV PPM_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/package-manager/2025.09/Containerfile.ubuntu2404.min
+++ b/package-manager/2025.09/Containerfile.ubuntu2404.min
@@ -14,7 +14,8 @@ ENV PPM_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/package-manager/2025.09/Containerfile.ubuntu2404.std
+++ b/package-manager/2025.09/Containerfile.ubuntu2404.std
@@ -24,7 +24,8 @@ ENV PPM_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/package-manager/2025.12/Containerfile.ubuntu2204.min
+++ b/package-manager/2025.12/Containerfile.ubuntu2204.min
@@ -13,7 +13,8 @@ ENV PPM_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/package-manager/2025.12/Containerfile.ubuntu2204.std
+++ b/package-manager/2025.12/Containerfile.ubuntu2204.std
@@ -23,7 +23,8 @@ ENV PPM_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/package-manager/2025.12/Containerfile.ubuntu2404.min
+++ b/package-manager/2025.12/Containerfile.ubuntu2404.min
@@ -14,7 +14,8 @@ ENV PPM_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/package-manager/2025.12/Containerfile.ubuntu2404.std
+++ b/package-manager/2025.12/Containerfile.ubuntu2404.std
@@ -24,7 +24,8 @@ ENV PPM_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/package-manager/2026.04/Containerfile.ubuntu2204.min
+++ b/package-manager/2026.04/Containerfile.ubuntu2204.min
@@ -13,7 +13,8 @@ ENV PPM_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/package-manager/2026.04/Containerfile.ubuntu2204.std
+++ b/package-manager/2026.04/Containerfile.ubuntu2204.std
@@ -23,7 +23,8 @@ ENV PPM_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/package-manager/2026.04/Containerfile.ubuntu2404.min
+++ b/package-manager/2026.04/Containerfile.ubuntu2404.min
@@ -14,7 +14,8 @@ ENV PPM_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/package-manager/2026.04/Containerfile.ubuntu2404.std
+++ b/package-manager/2026.04/Containerfile.ubuntu2404.std
@@ -24,7 +24,8 @@ ENV PPM_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \


### PR DESCRIPTION
## Why

Adds `Acquire::Retries=3` and `Acquire::http(s)::Timeout=30` to `/etc/apt/apt.conf.d/99-retries` at the top of each first apt RUN. Transient timeouts on `archive.ubuntu.com` and `ports.ubuntu.com` now recover on retry instead of failing the build.

Surgical edit to the rendered Containerfiles to avoid touching unrelated files. The macro change producing this output going forward landed upstream:

- https://github.com/posit-dev/images-shared/pull/538