### PR TITLE
Restore `preview` devVersion stream

### DIFF
--- a/bakery.yaml
+++ b/bakery.yaml
@@ -40,6 +40,20 @@ images:
     devVersions:
       - sourceType: "stream"
         product: "package-manager"
+        stream: "preview"
+        os:
+          - name: Ubuntu 24.04
+            primary: true
+            platforms:
+              - linux/amd64
+              - linux/arm64
+          - name: Ubuntu 22.04
+        overrideRegistries:
+          - host: "ghcr.io"
+            namespace: "posit-dev"
+            repository: "package-manager-preview"
+      - sourceType: "stream"
+        product: "package-manager"
         stream: "daily"
         os:
           - name: Ubuntu 24.04


### PR DESCRIPTION
The `preview` devVersion stream was removed in #85 as a workaround for a
UID collision: dev-stream builds shared an image target UID with the
same-version release build, so `bakery ci merge` could match dev
metadata onto release targets and push dev artifacts to the production
registries.

That root cause is now fixed in images-shared — image target UIDs
encode the release stream, so dev and release builds no longer collide.
This reverts the workaround and re-enables the preview stream.

Related:

- https://github.com/posit-dev/images-shared/issues/553
- https://github.com/posit-dev/images-shared/pull/554
- https://github.com/posit-dev/images-package-manager/pull/85
