### PR TITLE
Expand CONTRIBUTING.md with maintainer task guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,15 +149,7 @@ Both workflows use `bakery-build-native.yml` for native multi-platform builds (a
 Images push to `docker.io/posit` and `ghcr.io/posit-dev` on main merges and scheduled runs.
 Dev images push to AWS ECR.
 
-### CI failure checklist
-
-1. **Check which workflow failed** — production vs development have different scopes
-2. **Read the failing step** — usually Build or Test
-3. **Common failures:**
-   - Python version not available in UV — a new Python minor version may not be in UV's release metadata yet
-   - ARM64 build failures — may be runner availability or platform-specific package issues
-   - Registry auth — Docker Hub requires `DOCKER_HUB_ACCESS_TOKEN`, ECR requires AWS OIDC
-4. **Cache issues** — builds use `--cache-registry ghcr.io/posit-dev` for layer caching; stale caches can cause unexpected behavior
+For CI failure diagnosis, see [CONTRIBUTING.md](CONTRIBUTING.md#diagnose-a-build-failure).
 
 ## Helm Integration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,8 +142,8 @@ All workflows call shared reusable workflows from `images-shared`:
 
 | Workflow | Schedule | What it builds | Shared workflow |
 |---|---|---|---|
-| `production.yml` | Weekly (Sun 03:15 UTC), PR, push to main | Production versions (excludes dev) | `bakery-build-native.yml` |
-| `development.yml` | Hourly, PR, push to main | Dev versions only (preview + daily streams) | `bakery-build-native.yml` |
+| `production.yml` | Weekly (Sun 01:15 UTC), PR, push to main | Production versions (excludes dev) | `bakery-build-native.yml` |
+| `development.yml` | Daily (07:45 UTC), PR, push to main | Dev versions only (preview + daily streams) | `bakery-build-native.yml` |
 
 Both workflows use `bakery-build-native.yml` for native multi-platform builds (amd64 + arm64).
 Images push to `docker.io/posit` and `ghcr.io/posit-dev` on main merges and scheduled runs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,10 +140,10 @@ bakery update files
 
 All workflows call shared reusable workflows from `images-shared`:
 
-| Workflow | Schedule | What it builds | Shared workflow |
-|---|---|---|---|
-| `production.yml` | Weekly (Sun 01:15 UTC), PR, push to main | Production versions (excludes dev) | `bakery-build-native.yml` |
-| `development.yml` | Daily (07:45 UTC), PR, push to main | Dev versions only (preview + daily streams) | `bakery-build-native.yml` |
+| Workflow | What it builds | Shared workflow |
+|---|---|---|
+| `production.yml` | Production versions (excludes dev) | `bakery-build-native.yml` |
+| `development.yml` | Dev versions only (preview + daily streams) | `bakery-build-native.yml` |
 
 Both workflows use `bakery-build-native.yml` for native multi-platform builds (amd64 + arm64).
 Images push to `docker.io/posit` and `ghcr.io/posit-dev` on main merges and scheduled runs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,8 +142,8 @@ All workflows call shared reusable workflows from `images-shared`:
 
 | Workflow | Schedule | What it builds | Shared workflow |
 |---|---|---|---|
-| `production-builds.yml` | Weekly (Sun 03:15 UTC), PR, push to main | Production versions (excludes dev) | `bakery-build-native.yml` |
-| `development-builds.yml` | Hourly, PR, push to main | Dev versions only (preview + daily streams) | `bakery-build-native.yml` |
+| `production.yml` | Weekly (Sun 03:15 UTC), PR, push to main | Production versions (excludes dev) | `bakery-build-native.yml` |
+| `development.yml` | Hourly, PR, push to main | Dev versions only (preview + daily streams) | `bakery-build-native.yml` |
 
 Both workflows use `bakery-build-native.yml` for native multi-platform builds (amd64 + arm64).
 Images push to `docker.io/posit` and `ghcr.io/posit-dev` on main merges and scheduled runs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,10 +114,6 @@ bakery run dgoss --image-name package-manager --image-version 2025.12
 
 ### Footguns
 
-**Dev images push to AWS ECR, not Docker Hub.** The `development.yml` workflow
-requires `id-token: write` permission and the `AWS_ROLE` secret for ECR authentication.
-Docker Hub credentials are only used by `production.yml`.
-
 **PPM has two dev streams.** `bakery.yaml` defines both `preview` and `daily` dev
 version sources. A change to `dependencyConstraints` affects both streams.
 
@@ -128,12 +124,8 @@ version sources. A change to `dependencyConstraints` affects both streams.
 | Workflow | Schedule | Builds |
 |---|---|---|
 | `production.yml` | Weekly Sun 01:15 UTC, push to main, dispatch | `package-manager` (excludes dev) → Docker Hub + GHCR |
-| `development.yml` | Daily 07:45 UTC, push to main, dispatch | Dev stream (preview + daily) → AWS ECR |
+| `development.yml` | Daily 07:45 UTC, push to main, dispatch | Dev stream (preview + daily) → ghcr.io/posit-dev/package-manager-preview |
 
 Both workflows use `bakery-build-native.yml` (native amd64 + arm64 runners).
-
-**Package Manager-specific failure:** ECR auth on `development.yml`. ECR push requires
-`AWS_ROLE` secret and `id-token: write` on the job. Docker Hub auth errors only affect
-`production.yml`.
 
 → [Shared failure scenarios](https://github.com/posit-dev/images-shared/blob/main/CONTRIBUTING.md#diagnose-a-build-failure)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,62 +1,139 @@
 # Contributing to Posit Package Manager container images
 
-This guide covers how to build and test the Package Manager container images with the `bakery` CLI. To build images directly with Docker, Buildah, or Podman, see the [README](README.md#build). To deploy or run pre-built images, see the [running the image](README.md#running-the-image) section.
+This guide covers how to build and test the Package Manager container images locally,
+and how to perform common maintenance tasks. To build images directly with Docker,
+Buildah, or Podman, see the [README](README.md#build). To deploy or run pre-built
+images, see the [README](README.md#running-the-image).
 
-## Using `bakery`
-
-This repository follows the structure described in [bakery usage](https://github.com/posit-dev/images-shared/tree/main/posit-bakery#usage).
-
-Additional documentation:
-- [Configuration reference](https://github.com/posit-dev/images-shared/blob/main/posit-bakery/CONFIGURATION.md): `bakery.yaml` schema and options
-- [Templating reference](https://github.com/posit-dev/images-shared/blob/main/posit-bakery/TEMPLATING.md): Jinja2 macros for Containerfile templates
-- [CI workflows](https://github.com/posit-dev/images-shared/blob/main/CI.md): Shared GitHub Actions workflows for building and pushing images
-
-The [`bakery.yaml`](https://github.com/posit-dev/images-shared/blob/main/posit-bakery/CONFIGURATION.md#bakery-configuration) file, or project, is in the root of this repository.
+## Build and test
 
 ### Prerequisites
 
-Build prerequisites:
-
-* [python](https://docs.astral.sh/uv/guides/install-python/)
-* [uv](https://docs.astral.sh/uv/getting-started/installation/)
-* [docker buildx bake](https://github.com/docker/buildx#installing)
-* [just](https://just.systems/man/en/prerequisites.html)
-* `bakery`
-
-    ```shell
-    just install-bakery
-    ```
-
-* `goss` and `dgoss` for running image validation tests
-
-    ```shell
-    just install-goss
-    ```
-
-* [`pre-commit`](https://pre-commit.com/) hooks (for contributors)
-
-    ```shell
-    just setup
-    ```
-
-### Build with `bakery`
-
-By default, bakery creates an ephemeral JSON [bakefile](https://docs.bakefile.org/en/latest/language.html) to render all containers in parallel.
+| Tool | Install |
+|---|---|
+| [python](https://docs.astral.sh/uv/guides/install-python/) + [uv](https://docs.astral.sh/uv/getting-started/installation/) | Required for `bakery` |
+| [docker buildx bake](https://github.com/docker/buildx#installing) | Required for builds |
+| [just](https://just.systems/man/en/prerequisites.html) | Task runner |
 
 ```shell
+# Install bakery and goss
+just init
+
+# Install pre-commit hooks
+just setup
+```
+
+### Build
+
+```shell
+# Preview the build plan
+bakery build --plan
+
+# Build all images
 bakery build
+
+# Build a specific image version
+bakery build --image-name package-manager --image-version 2025.12
 ```
 
-You can view the bake plan using `bakery build --plan`.
-
-You can use CLI flags to build only a subset of images in the project.
-
-### Test images
-
-After building the container images, run the test suite for all images:
+### Test
 
 ```shell
+# Run goss tests for all images
 bakery run dgoss
+
+# Run goss tests for a specific image
+bakery run dgoss --image-name package-manager
 ```
 
-You can use CLI flags to limit the tests to run against a subset of images.
+### Re-render templates
+
+After changing any file in a `template/` directory, re-render the version directories:
+
+```shell
+bakery update files
+bakery update files --image-name package-manager --image-version 2025.12
+```
+
+## Maintainer tasks
+
+Each section below has Package Manager-specific context and a concrete example. The
+linked procedure in the [shared maintainer guide](https://github.com/posit-dev/images-shared/blob/main/CONTRIBUTING.md)
+covers the full workflow.
+
+### Add a version
+
+Package Manager versions are dispatched automatically from `rstudio/package-manager`
+via the `posit-package-manager-automation` GitHub App, which triggers this repo's
+`release.yml` workflow. Manual steps are only needed for hotfixes.
+
+```bash
+# Create a new version manually (e.g. a hotfix to 2025.12)
+bakery create version 2025.12.1 --image-name package-manager
+bakery update files --image-name package-manager --image-version 2025.12
+```
+
+→ [Shared procedure](https://github.com/posit-dev/images-shared/blob/main/CONTRIBUTING.md#add-a-version)
+
+### Add an image
+
+This repo has a single image (`package-manager`). Adding a new image requires
+coordination with the Package Manager product team.
+
+```bash
+# Scaffold a new image directory and template
+bakery create image <new-image-name>
+```
+
+→ [Shared procedure](https://github.com/posit-dev/images-shared/blob/main/CONTRIBUTING.md#add-an-image)
+
+### Update dependencies
+
+`package-manager` uses `dependencyConstraints: latest: true` for R and Python — bakery
+resolves the current latest at build time.
+
+```bash
+# After changing dependencyConstraints in bakery.yaml, re-render
+bakery update files --image-name package-manager
+```
+
+→ [Shared procedure](https://github.com/posit-dev/images-shared/blob/main/CONTRIBUTING.md#update-dependencies)
+
+### Update older versions
+
+```bash
+# Edit the template, then re-render a specific edition
+bakery update files --image-name package-manager --image-version 2025.12
+
+# Build and test before opening a PR
+bakery build --image-name package-manager --image-version 2025.12
+bakery run dgoss --image-name package-manager --image-version 2025.12
+```
+
+→ [Shared procedure](https://github.com/posit-dev/images-shared/blob/main/CONTRIBUTING.md#update-older-versions)
+
+### Footguns
+
+**Dev images push to AWS ECR, not Docker Hub.** The `development.yml` workflow
+requires `id-token: write` permission and the `AWS_ROLE` secret for ECR authentication.
+Docker Hub credentials are only used by `production.yml`.
+
+**PPM has two dev streams.** `bakery.yaml` defines both `preview` and `daily` dev
+version sources. A change to `dependencyConstraints` affects both streams.
+
+→ [Shared footguns](https://github.com/posit-dev/images-shared/blob/main/CONTRIBUTING.md#footguns)
+
+### Diagnose a build failure
+
+| Workflow | Schedule | Builds |
+|---|---|---|
+| `production.yml` | Weekly Sun 01:15 UTC, push to main, dispatch | `package-manager` (excludes dev) → Docker Hub + GHCR |
+| `development.yml` | Daily 07:45 UTC, push to main, dispatch | Dev stream (preview + daily) → AWS ECR |
+
+Both workflows use `bakery-build-native.yml` (native amd64 + arm64 runners).
+
+**Package Manager-specific failure:** ECR auth on `development.yml`. ECR push requires
+`AWS_ROLE` secret and `id-token: write` on the job. Docker Hub auth errors only affect
+`production.yml`.
+
+→ [Shared failure scenarios](https://github.com/posit-dev/images-shared/blob/main/CONTRIBUTING.md#diagnose-a-build-failure)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,8 @@ bakery run dgoss --image-name package-manager
 After changing any file in a `template/` directory, re-render the version directories:
 
 ```shell
-bakery update files
+# Omitting filters re-renders every image and version; --help shows available filters
+bakery update files --help
 bakery update files --image-name package-manager --image-version 2025.12
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,10 +65,10 @@ covers the full workflow.
 
 Package Manager versions are dispatched automatically from `rstudio/package-manager`
 via the `posit-package-manager-automation` GitHub App, which triggers this repo's
-`release.yml` workflow. Manual steps are only needed for hotfixes.
+`release.yml` workflow. Use manual steps only for hotfixes.
 
 ```bash
-# Create a new version manually (e.g. a hotfix to 2025.12)
+# Create a new version manually (e.g., a hotfix to 2025.12)
 bakery create version 2025.12.1 --image-name package-manager
 bakery update files --image-name package-manager --image-version 2025.12
 ```
@@ -114,7 +114,7 @@ bakery run dgoss --image-name package-manager --image-version 2025.12
 
 ### Footguns
 
-**PPM has two dev streams.** `bakery.yaml` defines both `preview` and `daily` dev
+**Package Manager has two dev streams.** `bakery.yaml` defines both `preview` and `daily` dev
 version sources. A change to `dependencyConstraints` affects both streams.
 
 → [Shared footguns](https://github.com/posit-dev/images-shared/blob/main/CONTRIBUTING.md#footguns)

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ podman build \
 ## Contributing
 
 To build images with `bakery` or run the test suite, see the [contributing guide](CONTRIBUTING.md).
+For image maintainers, the contributing guide also covers adding versions, updating
+dependencies, backporting to older versions, known footguns, and CI failure diagnosis.
 
 ## Related repositories
 


### PR DESCRIPTION
The existing CONTRIBUTING.md covered only local build and test. A new maintainer had no documented path for the six most common operations: adding a version, adding an image, updating dependencies, backporting to older versions, avoiding footguns, and diagnosing CI failures.

This rewrites CONTRIBUTING.md with a maintainer task guide. Each section has Package Manager-specific context and a concrete example inline, then links to the shared procedure in images-shared for depth.

Also:
- Removes the CI failure checklist from CLAUDE.md — content now lives in CONTRIBUTING.md
- Removes the schedule column from the CLAUDE.md CI workflow table (schedules are the authoritative version in CONTRIBUTING.md, eliminating the drift that caused stale values)
- Corrects pre-existing inaccuracies in the CI workflow table (wrong workflow filenames `production-builds.yml` / `development-builds.yml`, wrong schedule times)

Part of a coordinated change across four repos:
- https://github.com/posit-dev/images-shared/pull/564
- https://github.com/posit-dev/images-connect/pull/118
- https://github.com/posit-dev/images-workbench/pull/new/add-maintainer-contributing-docs