### PR TITLE
feat: install R via manylinux_2_34 tarball on RHEL 10

### DIFF
--- a/bakery.yaml
+++ b/bakery.yaml
@@ -48,6 +48,10 @@ images:
               - linux/amd64
               - linux/arm64
           - name: Ubuntu 22.04
+          - name: RHEL 10
+            platforms:
+              - linux/amd64
+              - linux/arm64
         overrideRegistries:
           - host: "ghcr.io"
             namespace: "posit-dev"
@@ -62,6 +66,10 @@ images:
               - linux/amd64
               - linux/arm64
           - name: Ubuntu 22.04
+          - name: RHEL 10
+            platforms:
+              - linux/amd64
+              - linux/arm64
         overrideRegistries:
           - host: "ghcr.io"
             namespace: "posit-dev"
@@ -86,6 +94,10 @@ images:
           - name: Ubuntu 22.04
           - name: Ubuntu 24.04
             primary: true
+            platforms:
+              - linux/amd64
+              - linux/arm64
+          - name: RHEL 10
             platforms:
               - linux/amd64
               - linux/arm64

--- a/package-manager/2026.05/Containerfile.rhel10.min
+++ b/package-manager/2026.05/Containerfile.rhel10.min
@@ -1,5 +1,7 @@
-FROM registry.access.redhat.com/ubi10/ubi:10.2
-LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi:10.2"
+# latest is intentional: pulls security errata automatically on each rebuild,
+# equivalent to ubuntu:24.04 which also floats within the LTS release.
+FROM registry.access.redhat.com/ubi10/ubi:latest
+LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi:latest"
 
 ### ARG declarations ###
 ARG TARGETARCH

--- a/package-manager/2026.05/Containerfile.rhel10.min
+++ b/package-manager/2026.05/Containerfile.rhel10.min
@@ -1,5 +1,5 @@
-FROM registry.access.redhat.com/ubi10/ubi:latest
-LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi:latest"
+FROM registry.access.redhat.com/ubi10/ubi:10.2
+LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi:10.2"
 
 ### ARG declarations ###
 ARG TARGETARCH

--- a/package-manager/2026.05/Containerfile.rhel10.min
+++ b/package-manager/2026.05/Containerfile.rhel10.min
@@ -1,0 +1,53 @@
+FROM registry.access.redhat.com/ubi10/ubi:latest
+LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi:latest"
+
+### ARG declarations ###
+ARG TARGETARCH
+ARG PACKAGE_MANAGER_VERSION="2026.05.0"
+
+ENV PPM_LICENSE=""
+ENV PPM_LICENSE_SERVER=""
+ENV PPM_LICENSE_FILE_PATH=""
+ENV PPM_STARTUP_DEBUG=0
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+### Setup environment (upgrades packages + installs curl/tar/gnupg + configures Posit Pro repo) ###
+RUN dnf upgrade -yq && \
+    dnf install -yq --allowerasing \
+        curl \
+        ca-certificates \
+        findutils \
+        gnupg \
+        tar && \
+    bash -c "$(curl -1fsSL 'https://dl.posit.co/public/pro/setup.rpm.sh')" && \
+    dnf clean all -yq
+
+### Install dnf packages ###
+COPY package-manager/2026.05/deps/rhel-10_packages.txt /tmp/packages.txt
+RUN xargs -a /tmp/packages.txt dnf install -yq && \
+    dnf clean all -yq
+
+
+
+### Install Package Manager 2026.05.0 ###
+COPY --chmod=0755 package-manager/2026.05/scripts/install_package_manager.rhel10.sh /tmp/install_package_manager.sh
+RUN \
+    /tmp/install_package_manager.sh \
+    && rm -f /tmp/install_package_manager.sh
+
+### Add startup.sh script ###
+COPY --chmod=0775 package-manager/2026.05/scripts/startup.sh /usr/local/bin/startup.sh
+RUN mkdir -p /var/run/rstudio-pm \
+    && chmod +x /usr/local/bin/startup.sh \
+    && chown rstudio-pm:rstudio-pm /usr/local/bin/startup.sh \
+    && chown -R rstudio-pm:rstudio-pm /var/run/rstudio-pm
+
+USER rstudio-pm
+
+RUN echo "source <(rspm completion bash)" >> ~/.bashrc
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD curl -fsS http://localhost:4242/__ping__ || exit 1
+
+CMD ["/usr/local/bin/startup.sh"]

--- a/package-manager/2026.05/Containerfile.rhel10.std
+++ b/package-manager/2026.05/Containerfile.rhel10.std
@@ -8,8 +8,8 @@ RUN uv python install 3.14.5
 RUN mv /opt/python/cpython-3.14.5-linux-*/ /opt/python/3.14.5
 
 
-FROM registry.access.redhat.com/ubi10/ubi:latest
-LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi:latest"
+FROM registry.access.redhat.com/ubi10/ubi:10.2
+LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi:10.2"
 
 ### ARG declarations ###
 ARG TARGETARCH

--- a/package-manager/2026.05/Containerfile.rhel10.std
+++ b/package-manager/2026.05/Containerfile.rhel10.std
@@ -1,0 +1,74 @@
+# Build Python using uv in a separate stage
+FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
+
+ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
+ENV UV_PYTHON_INSTALL_DIR=/opt/python
+ENV UV_PYTHON_PREFERENCE=only-managed
+RUN uv python install 3.14.5
+RUN mv /opt/python/cpython-3.14.5-linux-*/ /opt/python/3.14.5
+
+
+FROM registry.access.redhat.com/ubi10/ubi:latest
+LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi:latest"
+
+### ARG declarations ###
+ARG TARGETARCH
+ARG PACKAGE_MANAGER_VERSION="2026.05.0"
+
+ENV PPM_LICENSE=""
+ENV PPM_LICENSE_SERVER=""
+ENV PPM_LICENSE_FILE_PATH=""
+ENV PPM_STARTUP_DEBUG=0
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+### Setup environment (upgrades packages + installs curl/tar/gnupg + configures Posit Pro repo) ###
+RUN dnf upgrade -yq && \
+    dnf install -yq --allowerasing \
+        curl \
+        ca-certificates \
+        findutils \
+        gnupg \
+        tar && \
+    bash -c "$(curl -1fsSL 'https://dl.posit.co/public/pro/setup.rpm.sh')" && \
+    dnf clean all -yq
+
+### Install dnf packages ###
+COPY package-manager/2026.05/deps/rhel-10_packages.txt /tmp/packages.txt
+RUN xargs -a /tmp/packages.txt dnf install -yq && \
+    dnf clean all -yq
+
+### Install Python from previous stage ###
+COPY --from=python-builder /opt/python /opt/python
+
+### Install Python packages ###
+COPY package-manager/2026.05/deps/python_requirements.txt /tmp/requirements.txt
+RUN /opt/python/3.14.5/bin/pip install --no-cache-dir --upgrade --break-system-packages \
+        -r /tmp/requirements.txt && \
+    rm -f /tmp/requirements.txt
+
+### Install R ###
+RUN RUN_UNATTENDED=1 R_VERSION=4.6.0 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \
+    find . -type f -name '[rR]-4.6.0.*\.(deb|rpm)' -delete
+
+### Install Package Manager 2026.05.0 ###
+COPY --chmod=0755 package-manager/2026.05/scripts/install_package_manager.rhel10.sh /tmp/install_package_manager.sh
+RUN PYTHON_VERSION=3.14.5 R_VERSION=4.6.0 \
+    /tmp/install_package_manager.sh \
+    && rm -f /tmp/install_package_manager.sh
+
+### Add startup.sh script ###
+COPY --chmod=0775 package-manager/2026.05/scripts/startup.sh /usr/local/bin/startup.sh
+RUN mkdir -p /var/run/rstudio-pm \
+    && chmod +x /usr/local/bin/startup.sh \
+    && chown rstudio-pm:rstudio-pm /usr/local/bin/startup.sh \
+    && chown -R rstudio-pm:rstudio-pm /var/run/rstudio-pm
+
+USER rstudio-pm
+
+RUN echo "source <(rspm completion bash)" >> ~/.bashrc
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD curl -fsS http://localhost:4242/__ping__ || exit 1
+
+CMD ["/usr/local/bin/startup.sh"]

--- a/package-manager/2026.05/Containerfile.rhel10.std
+++ b/package-manager/2026.05/Containerfile.rhel10.std
@@ -50,8 +50,11 @@ RUN /opt/python/3.14.5/bin/pip install --no-cache-dir --upgrade --break-system-p
     rm -f /tmp/requirements.txt
 
 ### Install R ###
-RUN RUN_UNATTENDED=1 R_VERSION=4.6.0 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \
-    find . -type f -name '[rR]-4.6.0.*\.(deb|rpm)' -delete
+RUN mkdir -p /opt/R
+RUN ARCH=$(uname -m) && \
+    ARCH_SUFFIX=$([ "$ARCH" = "aarch64" ] && echo "-arm64" || echo "") && \
+    curl -fsSL "https://cdn.posit.co/r/manylinux_2_34/R-4.6.0-manylinux_2_34${ARCH_SUFFIX}.tar.gz" \
+        | tar -xz -C /opt/R/
 
 ### Install Package Manager 2026.05.0 ###
 COPY --chmod=0755 package-manager/2026.05/scripts/install_package_manager.rhel10.sh /tmp/install_package_manager.sh

--- a/package-manager/2026.05/Containerfile.rhel10.std
+++ b/package-manager/2026.05/Containerfile.rhel10.std
@@ -8,8 +8,10 @@ RUN uv python install 3.14.5
 RUN mv /opt/python/cpython-3.14.5-linux-*/ /opt/python/3.14.5
 
 
-FROM registry.access.redhat.com/ubi10/ubi:10.2
-LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi:10.2"
+# latest is intentional: pulls security errata automatically on each rebuild,
+# equivalent to ubuntu:24.04 which also floats within the LTS release.
+FROM registry.access.redhat.com/ubi10/ubi:latest
+LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi:latest"
 
 ### ARG declarations ###
 ARG TARGETARCH

--- a/package-manager/2026.05/deps/rhel-10_packages.txt
+++ b/package-manager/2026.05/deps/rhel-10_packages.txt
@@ -1,0 +1,2 @@
+glibc
+openssl

--- a/package-manager/2026.05/scripts/install_package_manager.rhel10.sh
+++ b/package-manager/2026.05/scripts/install_package_manager.rhel10.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -eo pipefail
+
+# Output delimiter
+d="===="
+
+echo "$d Install Posit Package Manager 2026.05.0 $d"
+
+RSTUDIO_INSTALL_NO_LICENSE_INITIALIZATION=1 dnf install -yq rstudio-pm-2026.05.0
+
+PPM_CONFIG_FILE="/etc/rstudio-pm/rstudio-pm.gcfg"
+
+if [ -n "$R_VERSION" ] && [ -n "$PYTHON_VERSION" ]
+then
+    # The default rstudio-pm.gcfg has an RVersion section already, let's comment that out.
+    sed -i 's/RVersion =/;RVersion =/' $PPM_CONFIG_FILE
+
+    echo "$d Setting R and Python version configuration $d"
+    sed -i "0,/.*RVersion.*/s||RVersion = /opt/R/$R_VERSION\nPythonVersion = /opt/python/$PYTHON_VERSION/bin/python|" $PPM_CONFIG_FILE
+
+    # Git package builds require R or Python and would otherwise fail because
+    # Package Manager's process sandbox is unavailable in containers. Allow
+    # unsandboxed Git builds so they work out of the box. This is gated on
+    # R_VERSION/PYTHON_VERSION being set, which is true only for the Standard
+    # variant -- Minimal users extending the image opt in by setting the
+    # option themselves once they install R or Python.
+    echo "$d Allowing unsandboxed Git builds $d"
+    if grep -q '^\[Git\]' $PPM_CONFIG_FILE; then
+        sed -i '/^\[Git\]/a AllowUnsandboxedGitBuilds = true' $PPM_CONFIG_FILE
+    else
+        printf '\n[Git]\nAllowUnsandboxedGitBuilds = true\n' >> $PPM_CONFIG_FILE
+    fi
+else
+    echo "$d No R or Python version provided $d"
+fi
+
+# clean up
+dnf clean all -yq

--- a/package-manager/2026.05/test/goss.yaml
+++ b/package-manager/2026.05/test/goss.yaml
@@ -1,13 +1,13 @@
 user:
   rstudio-pm:
     exists: true
-    uid: 999
-    gid: 999
+    uid: {{ if eq .Env.IMAGE_OS_FAMILY "rhel" }}998{{ else }}999{{ end }}
+    gid: {{ if eq .Env.IMAGE_OS_FAMILY "rhel" }}997{{ else }}999{{ end }}
 
 group:
   rstudio-pm:
     exists: true
-    gid: 999
+    gid: {{ if eq .Env.IMAGE_OS_FAMILY "rhel" }}997{{ else }}999{{ end }}
 
 package:
   rstudio-pm:

--- a/package-manager/template/Containerfile.rhel10.jinja2
+++ b/package-manager/template/Containerfile.rhel10.jinja2
@@ -44,7 +44,7 @@ COPY {{ Path.Version }}/deps/python_requirements.txt /tmp/requirements.txt
 {{ python.run_install_packages(Dependencies.python, requirements_file='/tmp/requirements.txt') }}
 
 ### Install R ###
-{{ r.run_install(Dependencies.R) }}
+{{ r.run_install_manylinux(Dependencies.R) }}
 {%- endif %}
 
 ### Install Package Manager {{ Image.Version }} ###

--- a/package-manager/template/Containerfile.rhel10.jinja2
+++ b/package-manager/template/Containerfile.rhel10.jinja2
@@ -12,8 +12,10 @@ Bakery handles bootstrapping the files into template rendering.
 
 {% endif -%}
 
-FROM registry.access.redhat.com/ubi10/ubi:10.2
-LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi:10.2"
+# latest is intentional: pulls security errata automatically on each rebuild,
+# equivalent to ubuntu:24.04 which also floats within the LTS release.
+FROM registry.access.redhat.com/ubi10/ubi:latest
+LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi:latest"
 
 ### ARG declarations ###
 ARG TARGETARCH

--- a/package-manager/template/Containerfile.rhel10.jinja2
+++ b/package-manager/template/Containerfile.rhel10.jinja2
@@ -12,8 +12,8 @@ Bakery handles bootstrapping the files into template rendering.
 
 {% endif -%}
 
-FROM registry.access.redhat.com/ubi10/ubi:latest
-LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi:latest"
+FROM registry.access.redhat.com/ubi10/ubi:10.2
+LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi:10.2"
 
 ### ARG declarations ###
 ARG TARGETARCH

--- a/package-manager/template/Containerfile.rhel10.jinja2
+++ b/package-manager/template/Containerfile.rhel10.jinja2
@@ -1,0 +1,68 @@
+{#-
+Below are imports for Bakery's macros. If any are unneeded, they can be removed.
+Bakery handles bootstrapping the files into template rendering.
+-#}
+{%- import "dnf.j2" as dnf -%}
+{%- import "python.j2" as python -%}
+{%- import "r.j2" as r -%}
+
+{%- if Image.Variant != "Minimal" -%}
+# Build Python using uv in a separate stage
+{{ python.build_stage(Dependencies.python) }}
+
+{% endif -%}
+
+FROM registry.access.redhat.com/ubi10/ubi:latest
+LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi:latest"
+
+### ARG declarations ###
+ARG TARGETARCH
+ARG PACKAGE_MANAGER_VERSION="{{ Image.Version }}"
+
+ENV PPM_LICENSE=""
+ENV PPM_LICENSE_SERVER=""
+ENV PPM_LICENSE_FILE_PATH=""
+ENV PPM_STARTUP_DEBUG=0
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+### Setup environment (upgrades packages + installs curl/tar/gnupg + configures Posit Pro repo) ###
+{{ dnf.run_setup() }}
+
+### Install dnf packages ###
+COPY {{ Path.Version }}/deps/rhel-10_packages.txt /tmp/packages.txt
+{{ dnf.run_install(files = '/tmp/packages.txt') }}
+
+{% if not Image.Variant == "Minimal" -%}
+### Install Python from previous stage ###
+{{ python.copy_from_build_stage() }}
+
+### Install Python packages ###
+COPY {{ Path.Version }}/deps/python_requirements.txt /tmp/requirements.txt
+{{ python.run_install_packages(Dependencies.python, requirements_file='/tmp/requirements.txt') }}
+
+### Install R ###
+{{ r.run_install(Dependencies.R) }}
+{%- endif %}
+
+### Install Package Manager {{ Image.Version }} ###
+COPY --chmod=0755 {{ Path.Version }}/scripts/install_package_manager.rhel10.sh /tmp/install_package_manager.sh
+RUN {% if Image.Variant != "Minimal" %}PYTHON_VERSION={{ Dependencies.python.0 }} R_VERSION={{ Dependencies.R.0 }} {% endif %}{% if Image.DownloadURL is defined %}DOWNLOAD_URL="{{ Image.DownloadURL }}" {% endif %}\
+    /tmp/install_package_manager.sh \
+    && rm -f /tmp/install_package_manager.sh
+
+### Add startup.sh script ###
+COPY --chmod=0775 {{ Path.Version }}/scripts/startup.sh /usr/local/bin/startup.sh
+RUN mkdir -p /var/run/rstudio-pm \
+    && chmod +x /usr/local/bin/startup.sh \
+    && chown rstudio-pm:rstudio-pm /usr/local/bin/startup.sh \
+    && chown -R rstudio-pm:rstudio-pm /var/run/rstudio-pm
+
+USER rstudio-pm
+
+RUN echo "source <(rspm completion bash)" >> ~/.bashrc
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD curl -fsS http://localhost:4242/__ping__ || exit 1
+
+CMD ["/usr/local/bin/startup.sh"]

--- a/package-manager/template/deps/rhel-10_packages.txt.jinja2
+++ b/package-manager/template/deps/rhel-10_packages.txt.jinja2
@@ -1,0 +1,2 @@
+glibc
+openssl

--- a/package-manager/template/scripts/install_package_manager.rhel10.sh.jinja2
+++ b/package-manager/template/scripts/install_package_manager.rhel10.sh.jinja2
@@ -1,0 +1,56 @@
+{#-
+Below are imports for Bakery's macros. If any are unneeded, they can be removed.
+Bakery handles bootstrapping the files into template rendering.
+-#}
+{%- import "python.j2" as python -%}
+{%- import "r.j2" as r -%}
+#!/bin/bash
+set -eo pipefail
+
+# Output delimiter
+d="===="
+
+{% if Image.IsDevelopmentVersion -%}
+echo "$d Fetching Posit Package Manager {{ Image.Version }} package $d"
+
+# fetch dev build rpm package
+curl -fsSL "$DOWNLOAD_URL" -o /tmp/rstudio-pm.rpm
+
+echo "$d Install Posit Package Manager {{ Image.Version }} $d"
+RSTUDIO_INSTALL_NO_LICENSE_INITIALIZATION=1 dnf install -yq /tmp/rstudio-pm.rpm
+
+rm -f /tmp/rstudio-pm.rpm
+{%- else -%}
+echo "$d Install Posit Package Manager {{ Image.Version }} $d"
+
+RSTUDIO_INSTALL_NO_LICENSE_INITIALIZATION=1 dnf install -yq rstudio-pm-{{ Image.Version }}
+{%- endif %}
+
+PPM_CONFIG_FILE="/etc/rstudio-pm/rstudio-pm.gcfg"
+
+if [ -n "$R_VERSION" ] && [ -n "$PYTHON_VERSION" ]
+then
+    # The default rstudio-pm.gcfg has an RVersion section already, let's comment that out.
+    sed -i 's/RVersion =/;RVersion =/' $PPM_CONFIG_FILE
+
+    echo "$d Setting R and Python version configuration $d"
+    sed -i "0,/.*RVersion.*/s||RVersion = {{ r.get_version_directory("$R_VERSION") }}\nPythonVersion = {{ python.get_version_directory("$PYTHON_VERSION") }}/bin/python|" $PPM_CONFIG_FILE
+
+    # Git package builds require R or Python and would otherwise fail because
+    # Package Manager's process sandbox is unavailable in containers. Allow
+    # unsandboxed Git builds so they work out of the box. This is gated on
+    # R_VERSION/PYTHON_VERSION being set, which is true only for the Standard
+    # variant -- Minimal users extending the image opt in by setting the
+    # option themselves once they install R or Python.
+    echo "$d Allowing unsandboxed Git builds $d"
+    if grep -q '^\[Git\]' $PPM_CONFIG_FILE; then
+        sed -i '/^\[Git\]/a AllowUnsandboxedGitBuilds = true' $PPM_CONFIG_FILE
+    else
+        printf '\n[Git]\nAllowUnsandboxedGitBuilds = true\n' >> $PPM_CONFIG_FILE
+    fi
+else
+    echo "$d No R or Python version provided $d"
+fi
+
+# clean up
+dnf clean all -yq

--- a/package-manager/template/test/goss.yaml.jinja2
+++ b/package-manager/template/test/goss.yaml.jinja2
@@ -12,13 +12,13 @@ Bakery handles bootstrapping the files into template rendering.
 user:
   rstudio-pm:
     exists: true
-    uid: 999
-    gid: 999
+    uid: {% raw %}{{ if eq .Env.IMAGE_OS_FAMILY "rhel" }}998{{ else }}999{{ end }}{% endraw %}
+    gid: {% raw %}{{ if eq .Env.IMAGE_OS_FAMILY "rhel" }}997{{ else }}999{{ end }}{% endraw %}
 
 group:
   rstudio-pm:
     exists: true
-    gid: 999
+    gid: {% raw %}{{ if eq .Env.IMAGE_OS_FAMILY "rhel" }}997{{ else }}999{{ end }}{% endraw %}
 
 package:
   rstudio-pm:


### PR DESCRIPTION
Switches the RHEL 10 Containerfile from `r.run_install()` to `r.run_install_manylinux()`. Standard dgoss now passes 30/30 with R 4.6.0 installed from the manylinux tarball. Depends on the images-shared macro PR.