### PR TITLE
Use dev-version/dev-channel to pin dispatched dev builds

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Product version to build (e.g. 2026.04.0)"
+        description: "Pinned dev version string (e.g. '2026.06.0-dev+156-gcff5d15b7f'). When set, bypasses CDN discovery."
         required: false
         type: string
       stream:
-        description: "Dev stream to build (e.g. 'daily', 'preview')"
+        description: "Dev channel to build (e.g. 'daily', 'preview'). When set with version, only that channel is built."
         required: false
         type: string
 
@@ -63,8 +63,8 @@ jobs:
     uses: "posit-dev/images-shared/.github/workflows/bakery-build-native.yml@main"
     with:
       dev-versions: "only"
-      image-version: ${{ inputs.version }}
-      dev-stream: ${{ inputs.stream }}
+      dev-version: ${{ inputs.version }}
+      dev-channel: ${{ inputs.stream }}
       # Push on merges to main, scheduled rebuilds, and dispatches targeting main.
       push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
 

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -11,6 +11,10 @@ on:
         description: "Dev channel to build (e.g. 'daily', 'preview'). When set with version, only that channel is built."
         required: false
         type: string
+      stream:
+        description: "Deprecated: use channel instead."
+        required: false
+        type: string
 
   schedule:
     # Daily rebuild of dev images. Staggered with images-connect (08:45)
@@ -64,7 +68,7 @@ jobs:
     with:
       dev-versions: "only"
       dev-version: ${{ inputs.version }}
-      dev-channel: ${{ inputs.channel }}
+      dev-channel: ${{ inputs.channel || inputs.stream }}
       # Push on merges to main, scheduled rebuilds, and dispatches targeting main.
       push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
 

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -7,7 +7,7 @@ on:
         description: "Pinned dev version string (e.g. '2026.06.0-dev+156-gcff5d15b7f'). When set, bypasses CDN discovery."
         required: false
         type: string
-      stream:
+      channel:
         description: "Dev channel to build (e.g. 'daily', 'preview'). When set with version, only that channel is built."
         required: false
         type: string
@@ -64,7 +64,7 @@ jobs:
     with:
       dev-versions: "only"
       dev-version: ${{ inputs.version }}
-      dev-channel: ${{ inputs.stream }}
+      dev-channel: ${{ inputs.channel }}
       # Push on merges to main, scheduled rebuilds, and dispatches targeting main.
       push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
 


### PR DESCRIPTION
Switches `development.yml` from `image-version`/`dev-stream` to `dev-version`/`dev-channel`, matching the interface added in posit-dev/images-shared#565. Adds `channel` as the new dispatch input and keeps `stream` as a deprecated alias so existing callers are not broken until they migrate.

Must be merged before:
- https://github.com/rstudio/package-manager/pull/18308
- https://github.com/posit-dev/images-package-manager/pull/106