### PR TITLE
Remove deprecated stream input from development.yml

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -11,10 +11,6 @@ on:
         description: "Dev channel to build (e.g. 'daily', 'preview'). When set with version, only that channel is built."
         required: false
         type: string
-      stream:
-        description: "Deprecated: use channel instead."
-        required: false
-        type: string
 
   schedule:
     # Daily rebuild of dev images. Staggered with images-connect (08:45)
@@ -68,7 +64,7 @@ jobs:
     with:
       dev-versions: "only"
       dev-version: ${{ inputs.version }}
-      dev-channel: ${{ inputs.channel || inputs.stream }}
+      dev-channel: ${{ inputs.channel }}
       # Push on merges to main, scheduled rebuilds, and dispatches targeting main.
       push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
 


### PR DESCRIPTION
Removes the `stream` compatibility alias added in #105, now that all callers have switched to `channel`.

Must be merged after:
- https://github.com/posit-dev/images-package-manager/pull/105
- https://github.com/rstudio/package-manager/pull/18308