### PR TITLE
Fix license file activation for non-root containers

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,8 @@
 name: Pull Request
 on:
   pull_request:
+  merge_group:
+    types: [checks_requested]
 
 
 concurrency:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,6 @@ name: Pull Request
 on:
   pull_request:
   merge_group:
-    types: [checks_requested]
 
 
 concurrency:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,8 +21,15 @@ jobs:
       - zizmor
     steps:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # v1.2.2
+        id: alls-green
         with:
           jobs: ${{ toJSON(needs) }}
+      - if: always() && github.event_name == 'merge_group'
+        continue-on-error: true
+        uses: posit-dev/images-shared/.github/actions/slack-build-notify@main
+        with:
+          result: ${{ steps.alls-green.outcome }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   lint:
     name: Lint

--- a/bakery.yaml
+++ b/bakery.yaml
@@ -48,6 +48,10 @@ images:
               - linux/amd64
               - linux/arm64
           - name: Ubuntu 22.04
+          - name: RHEL 10
+            platforms:
+              - linux/amd64
+              - linux/arm64
         overrideRegistries:
           - host: "ghcr.io"
             namespace: "posit-dev"
@@ -62,6 +66,10 @@ images:
               - linux/amd64
               - linux/arm64
           - name: Ubuntu 22.04
+          - name: RHEL 10
+            platforms:
+              - linux/amd64
+              - linux/arm64
         overrideRegistries:
           - host: "ghcr.io"
             namespace: "posit-dev"
@@ -86,6 +94,10 @@ images:
           - name: Ubuntu 22.04
           - name: Ubuntu 24.04
             primary: true
+            platforms:
+              - linux/amd64
+              - linux/arm64
+          - name: RHEL 10
             platforms:
               - linux/amd64
               - linux/arm64

--- a/package-manager/2025.04/scripts/startup.sh
+++ b/package-manager/2025.04/scripts/startup.sh
@@ -48,11 +48,10 @@ elif ! [ -z "$PPM_LICENSE_SERVER" ]; then
 elif test -f "$PPM_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/rspm/admin/licensing.html
-    _tmp_lic=$(mktemp)
-    cp "${PPM_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    rm -f /var/lib/rstudio-pm/*.lic
-    mv "${_tmp_lic}" /var/lib/rstudio-pm/license.lic
-    chmod 0600 /var/lib/rstudio-pm/license.lic
+    if [ "${PPM_LICENSE_FILE_PATH}" != "/var/lib/rstudio-pm/license.lic" ]; then
+        cp "${PPM_LICENSE_FILE_PATH}" /var/lib/rstudio-pm/license.lic
+        chmod 0600 /var/lib/rstudio-pm/license.lic
+    fi
 elif ls /var/lib/rstudio-pm/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in /var/lib/rstudio-pm/*.lic."
 elif ls /home/rstudio-pm/.rstudio-pm/*.lic >/dev/null 2>&1; then

--- a/package-manager/2025.04/scripts/startup.sh
+++ b/package-manager/2025.04/scripts/startup.sh
@@ -52,6 +52,10 @@ elif test -f "$PPM_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/rspm/admin/licensing.html
     if [ "$(dirname "${PPM_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        if mountpoint -q "${_license_dir}"; then
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PPM_LICENSE_FILE_PATH."
+            exit 1
+        fi
         cp "${PPM_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi

--- a/package-manager/2025.04/scripts/startup.sh
+++ b/package-manager/2025.04/scripts/startup.sh
@@ -40,22 +40,26 @@ PPM_LICENSE_FILE_PATH=${PPM_LICENSE_FILE_PATH:-$RSPM_LICENSE_FILE_PATH}
 
 # Activate License
 PPM_LICENSE_FILE_PATH=${PPM_LICENSE_FILE_PATH:-/etc/rstudio-pm/license.lic}
+_license_dir=/var/lib/rstudio-pm
 /opt/rstudio-pm/bin/license-manager initialize --userspace || true
 if ! [ -z "$PPM_LICENSE" ]; then
+    echo "Activating license key."
     /opt/rstudio-pm/bin/license-manager activate "$PPM_LICENSE" --userspace
 elif ! [ -z "$PPM_LICENSE_SERVER" ]; then
+    echo "Activating floating license server."
     /opt/rstudio-pm/bin/license-manager license-server "$PPM_LICENSE_SERVER" --userspace
 elif test -f "$PPM_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/rspm/admin/licensing.html
-    if [ "${PPM_LICENSE_FILE_PATH}" != "/var/lib/rstudio-pm/license.lic" ]; then
-        cp "${PPM_LICENSE_FILE_PATH}" /var/lib/rstudio-pm/license.lic
-        chmod 0600 /var/lib/rstudio-pm/license.lic
+    if [ "$(dirname "${PPM_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        cp "${PPM_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+        chmod 0600 "${_license_dir}/license.lic"
     fi
-elif ls /var/lib/rstudio-pm/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in /var/lib/rstudio-pm/*.lic."
+    echo "Using license file at ${PPM_LICENSE_FILE_PATH}."
+elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in ${_license_dir}/."
 elif ls /home/rstudio-pm/.rstudio-pm/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in /home/rstudio-pm/.rstudio-pm/*.lic."
+    echo "Detected a license file in /home/rstudio-pm/.rstudio-pm/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/package-manager/2025.04/scripts/startup.sh
+++ b/package-manager/2025.04/scripts/startup.sh
@@ -43,25 +43,23 @@ PPM_LICENSE_FILE_PATH=${PPM_LICENSE_FILE_PATH:-/etc/rstudio-pm/license.lic}
 _license_dir=/var/lib/rstudio-pm
 /opt/rstudio-pm/bin/license-manager initialize --userspace || true
 if ! [ -z "$PPM_LICENSE" ]; then
-    echo "Activating license key."
     /opt/rstudio-pm/bin/license-manager activate "$PPM_LICENSE" --userspace
 elif ! [ -z "$PPM_LICENSE_SERVER" ]; then
-    echo "Activating floating license server."
     /opt/rstudio-pm/bin/license-manager license-server "$PPM_LICENSE_SERVER" --userspace
 elif test -f "$PPM_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/rspm/admin/licensing.html
     if [ "$(dirname "${PPM_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
         if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PPM_LICENSE_FILE_PATH."
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PPM_LICENSE_FILE_PATH." >&2
             exit 1
         fi
         cp "${PPM_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi
-    echo "Using license file at ${PPM_LICENSE_FILE_PATH}."
+    echo "Using license file at ${PPM_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in ${_license_dir}/."
+    echo "Detected a license file in ${_license_dir}/." >&2
 fi
 
 # ensure these cannot be inherited by child processes

--- a/package-manager/2025.04/scripts/startup.sh
+++ b/package-manager/2025.04/scripts/startup.sh
@@ -58,8 +58,6 @@ elif test -f "$PPM_LICENSE_FILE_PATH"; then
     echo "Using license file at ${PPM_LICENSE_FILE_PATH}."
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/."
-elif ls /home/rstudio-pm/.rstudio-pm/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in /home/rstudio-pm/.rstudio-pm/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/package-manager/2025.04/scripts/startup.sh
+++ b/package-manager/2025.04/scripts/startup.sh
@@ -46,7 +46,11 @@ if ! [ -z "$PPM_LICENSE" ]; then
 elif ! [ -z "$PPM_LICENSE_SERVER" ]; then
     /opt/rstudio-pm/bin/license-manager license-server "$PPM_LICENSE_SERVER" --userspace
 elif test -f "$PPM_LICENSE_FILE_PATH"; then
-    /opt/rstudio-pm/bin/license-manager activate-file "$PPM_LICENSE_FILE_PATH" --userspace
+    _tmp_lic=$(mktemp)
+    cp "${PPM_LICENSE_FILE_PATH}" "${_tmp_lic}"
+    mkdir -p /home/rstudio-pm/.rstudio-pm
+    mv "${_tmp_lic}" /home/rstudio-pm/.rstudio-pm/license.lic
+    chmod 0600 /home/rstudio-pm/.rstudio-pm/license.lic
 elif ls /var/lib/rstudio-pm/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in /var/lib/rstudio-pm/*.lic."
 elif ls /home/rstudio-pm/.rstudio-pm/*.lic >/dev/null 2>&1; then

--- a/package-manager/2025.04/scripts/startup.sh
+++ b/package-manager/2025.04/scripts/startup.sh
@@ -46,11 +46,13 @@ if ! [ -z "$PPM_LICENSE" ]; then
 elif ! [ -z "$PPM_LICENSE_SERVER" ]; then
     /opt/rstudio-pm/bin/license-manager license-server "$PPM_LICENSE_SERVER" --userspace
 elif test -f "$PPM_LICENSE_FILE_PATH"; then
+    # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
+    # https://docs.posit.co/rspm/admin/licensing.html
     _tmp_lic=$(mktemp)
     cp "${PPM_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    mkdir -p /home/rstudio-pm/.rstudio-pm
-    mv "${_tmp_lic}" /home/rstudio-pm/.rstudio-pm/license.lic
-    chmod 0600 /home/rstudio-pm/.rstudio-pm/license.lic
+    rm -f /var/lib/rstudio-pm/*.lic
+    mv "${_tmp_lic}" /var/lib/rstudio-pm/license.lic
+    chmod 0600 /var/lib/rstudio-pm/license.lic
 elif ls /var/lib/rstudio-pm/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in /var/lib/rstudio-pm/*.lic."
 elif ls /home/rstudio-pm/.rstudio-pm/*.lic >/dev/null 2>&1; then

--- a/package-manager/2025.09/scripts/startup.sh
+++ b/package-manager/2025.09/scripts/startup.sh
@@ -48,11 +48,10 @@ elif ! [ -z "$PPM_LICENSE_SERVER" ]; then
 elif test -f "$PPM_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/rspm/admin/licensing.html
-    _tmp_lic=$(mktemp)
-    cp "${PPM_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    rm -f /var/lib/rstudio-pm/*.lic
-    mv "${_tmp_lic}" /var/lib/rstudio-pm/license.lic
-    chmod 0600 /var/lib/rstudio-pm/license.lic
+    if [ "${PPM_LICENSE_FILE_PATH}" != "/var/lib/rstudio-pm/license.lic" ]; then
+        cp "${PPM_LICENSE_FILE_PATH}" /var/lib/rstudio-pm/license.lic
+        chmod 0600 /var/lib/rstudio-pm/license.lic
+    fi
 elif ls /var/lib/rstudio-pm/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in /var/lib/rstudio-pm/*.lic."
 elif ls /home/rstudio-pm/.rstudio-pm/*.lic >/dev/null 2>&1; then

--- a/package-manager/2025.09/scripts/startup.sh
+++ b/package-manager/2025.09/scripts/startup.sh
@@ -52,6 +52,10 @@ elif test -f "$PPM_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/rspm/admin/licensing.html
     if [ "$(dirname "${PPM_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        if mountpoint -q "${_license_dir}"; then
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PPM_LICENSE_FILE_PATH."
+            exit 1
+        fi
         cp "${PPM_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi

--- a/package-manager/2025.09/scripts/startup.sh
+++ b/package-manager/2025.09/scripts/startup.sh
@@ -40,22 +40,26 @@ PPM_LICENSE_FILE_PATH=${PPM_LICENSE_FILE_PATH:-$RSPM_LICENSE_FILE_PATH}
 
 # Activate License
 PPM_LICENSE_FILE_PATH=${PPM_LICENSE_FILE_PATH:-/etc/rstudio-pm/license.lic}
+_license_dir=/var/lib/rstudio-pm
 /opt/rstudio-pm/bin/license-manager initialize --userspace || true
 if ! [ -z "$PPM_LICENSE" ]; then
+    echo "Activating license key."
     /opt/rstudio-pm/bin/license-manager activate "$PPM_LICENSE" --userspace
 elif ! [ -z "$PPM_LICENSE_SERVER" ]; then
+    echo "Activating floating license server."
     /opt/rstudio-pm/bin/license-manager license-server "$PPM_LICENSE_SERVER" --userspace
 elif test -f "$PPM_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/rspm/admin/licensing.html
-    if [ "${PPM_LICENSE_FILE_PATH}" != "/var/lib/rstudio-pm/license.lic" ]; then
-        cp "${PPM_LICENSE_FILE_PATH}" /var/lib/rstudio-pm/license.lic
-        chmod 0600 /var/lib/rstudio-pm/license.lic
+    if [ "$(dirname "${PPM_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        cp "${PPM_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+        chmod 0600 "${_license_dir}/license.lic"
     fi
-elif ls /var/lib/rstudio-pm/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in /var/lib/rstudio-pm/*.lic."
+    echo "Using license file at ${PPM_LICENSE_FILE_PATH}."
+elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in ${_license_dir}/."
 elif ls /home/rstudio-pm/.rstudio-pm/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in /home/rstudio-pm/.rstudio-pm/*.lic."
+    echo "Detected a license file in /home/rstudio-pm/.rstudio-pm/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/package-manager/2025.09/scripts/startup.sh
+++ b/package-manager/2025.09/scripts/startup.sh
@@ -43,25 +43,23 @@ PPM_LICENSE_FILE_PATH=${PPM_LICENSE_FILE_PATH:-/etc/rstudio-pm/license.lic}
 _license_dir=/var/lib/rstudio-pm
 /opt/rstudio-pm/bin/license-manager initialize --userspace || true
 if ! [ -z "$PPM_LICENSE" ]; then
-    echo "Activating license key."
     /opt/rstudio-pm/bin/license-manager activate "$PPM_LICENSE" --userspace
 elif ! [ -z "$PPM_LICENSE_SERVER" ]; then
-    echo "Activating floating license server."
     /opt/rstudio-pm/bin/license-manager license-server "$PPM_LICENSE_SERVER" --userspace
 elif test -f "$PPM_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/rspm/admin/licensing.html
     if [ "$(dirname "${PPM_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
         if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PPM_LICENSE_FILE_PATH."
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PPM_LICENSE_FILE_PATH." >&2
             exit 1
         fi
         cp "${PPM_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi
-    echo "Using license file at ${PPM_LICENSE_FILE_PATH}."
+    echo "Using license file at ${PPM_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in ${_license_dir}/."
+    echo "Detected a license file in ${_license_dir}/." >&2
 fi
 
 # ensure these cannot be inherited by child processes

--- a/package-manager/2025.09/scripts/startup.sh
+++ b/package-manager/2025.09/scripts/startup.sh
@@ -58,8 +58,6 @@ elif test -f "$PPM_LICENSE_FILE_PATH"; then
     echo "Using license file at ${PPM_LICENSE_FILE_PATH}."
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/."
-elif ls /home/rstudio-pm/.rstudio-pm/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in /home/rstudio-pm/.rstudio-pm/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/package-manager/2025.09/scripts/startup.sh
+++ b/package-manager/2025.09/scripts/startup.sh
@@ -46,7 +46,11 @@ if ! [ -z "$PPM_LICENSE" ]; then
 elif ! [ -z "$PPM_LICENSE_SERVER" ]; then
     /opt/rstudio-pm/bin/license-manager license-server "$PPM_LICENSE_SERVER" --userspace
 elif test -f "$PPM_LICENSE_FILE_PATH"; then
-    /opt/rstudio-pm/bin/license-manager activate-file "$PPM_LICENSE_FILE_PATH" --userspace
+    _tmp_lic=$(mktemp)
+    cp "${PPM_LICENSE_FILE_PATH}" "${_tmp_lic}"
+    mkdir -p /home/rstudio-pm/.rstudio-pm
+    mv "${_tmp_lic}" /home/rstudio-pm/.rstudio-pm/license.lic
+    chmod 0600 /home/rstudio-pm/.rstudio-pm/license.lic
 elif ls /var/lib/rstudio-pm/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in /var/lib/rstudio-pm/*.lic."
 elif ls /home/rstudio-pm/.rstudio-pm/*.lic >/dev/null 2>&1; then

--- a/package-manager/2025.09/scripts/startup.sh
+++ b/package-manager/2025.09/scripts/startup.sh
@@ -46,11 +46,13 @@ if ! [ -z "$PPM_LICENSE" ]; then
 elif ! [ -z "$PPM_LICENSE_SERVER" ]; then
     /opt/rstudio-pm/bin/license-manager license-server "$PPM_LICENSE_SERVER" --userspace
 elif test -f "$PPM_LICENSE_FILE_PATH"; then
+    # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
+    # https://docs.posit.co/rspm/admin/licensing.html
     _tmp_lic=$(mktemp)
     cp "${PPM_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    mkdir -p /home/rstudio-pm/.rstudio-pm
-    mv "${_tmp_lic}" /home/rstudio-pm/.rstudio-pm/license.lic
-    chmod 0600 /home/rstudio-pm/.rstudio-pm/license.lic
+    rm -f /var/lib/rstudio-pm/*.lic
+    mv "${_tmp_lic}" /var/lib/rstudio-pm/license.lic
+    chmod 0600 /var/lib/rstudio-pm/license.lic
 elif ls /var/lib/rstudio-pm/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in /var/lib/rstudio-pm/*.lic."
 elif ls /home/rstudio-pm/.rstudio-pm/*.lic >/dev/null 2>&1; then

--- a/package-manager/2025.12/scripts/startup.sh
+++ b/package-manager/2025.12/scripts/startup.sh
@@ -48,11 +48,10 @@ elif ! [ -z "$PPM_LICENSE_SERVER" ]; then
 elif test -f "$PPM_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/rspm/admin/licensing.html
-    _tmp_lic=$(mktemp)
-    cp "${PPM_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    rm -f /var/lib/rstudio-pm/*.lic
-    mv "${_tmp_lic}" /var/lib/rstudio-pm/license.lic
-    chmod 0600 /var/lib/rstudio-pm/license.lic
+    if [ "${PPM_LICENSE_FILE_PATH}" != "/var/lib/rstudio-pm/license.lic" ]; then
+        cp "${PPM_LICENSE_FILE_PATH}" /var/lib/rstudio-pm/license.lic
+        chmod 0600 /var/lib/rstudio-pm/license.lic
+    fi
 elif ls /var/lib/rstudio-pm/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in /var/lib/rstudio-pm/*.lic."
 elif ls /home/rstudio-pm/.rstudio-pm/*.lic >/dev/null 2>&1; then

--- a/package-manager/2025.12/scripts/startup.sh
+++ b/package-manager/2025.12/scripts/startup.sh
@@ -52,6 +52,10 @@ elif test -f "$PPM_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/rspm/admin/licensing.html
     if [ "$(dirname "${PPM_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        if mountpoint -q "${_license_dir}"; then
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PPM_LICENSE_FILE_PATH."
+            exit 1
+        fi
         cp "${PPM_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi

--- a/package-manager/2025.12/scripts/startup.sh
+++ b/package-manager/2025.12/scripts/startup.sh
@@ -40,22 +40,26 @@ PPM_LICENSE_FILE_PATH=${PPM_LICENSE_FILE_PATH:-$RSPM_LICENSE_FILE_PATH}
 
 # Activate License
 PPM_LICENSE_FILE_PATH=${PPM_LICENSE_FILE_PATH:-/etc/rstudio-pm/license.lic}
+_license_dir=/var/lib/rstudio-pm
 /opt/rstudio-pm/bin/license-manager initialize --userspace || true
 if ! [ -z "$PPM_LICENSE" ]; then
+    echo "Activating license key."
     /opt/rstudio-pm/bin/license-manager activate "$PPM_LICENSE" --userspace
 elif ! [ -z "$PPM_LICENSE_SERVER" ]; then
+    echo "Activating floating license server."
     /opt/rstudio-pm/bin/license-manager license-server "$PPM_LICENSE_SERVER" --userspace
 elif test -f "$PPM_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/rspm/admin/licensing.html
-    if [ "${PPM_LICENSE_FILE_PATH}" != "/var/lib/rstudio-pm/license.lic" ]; then
-        cp "${PPM_LICENSE_FILE_PATH}" /var/lib/rstudio-pm/license.lic
-        chmod 0600 /var/lib/rstudio-pm/license.lic
+    if [ "$(dirname "${PPM_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        cp "${PPM_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+        chmod 0600 "${_license_dir}/license.lic"
     fi
-elif ls /var/lib/rstudio-pm/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in /var/lib/rstudio-pm/*.lic."
+    echo "Using license file at ${PPM_LICENSE_FILE_PATH}."
+elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in ${_license_dir}/."
 elif ls /home/rstudio-pm/.rstudio-pm/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in /home/rstudio-pm/.rstudio-pm/*.lic."
+    echo "Detected a license file in /home/rstudio-pm/.rstudio-pm/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/package-manager/2025.12/scripts/startup.sh
+++ b/package-manager/2025.12/scripts/startup.sh
@@ -43,25 +43,23 @@ PPM_LICENSE_FILE_PATH=${PPM_LICENSE_FILE_PATH:-/etc/rstudio-pm/license.lic}
 _license_dir=/var/lib/rstudio-pm
 /opt/rstudio-pm/bin/license-manager initialize --userspace || true
 if ! [ -z "$PPM_LICENSE" ]; then
-    echo "Activating license key."
     /opt/rstudio-pm/bin/license-manager activate "$PPM_LICENSE" --userspace
 elif ! [ -z "$PPM_LICENSE_SERVER" ]; then
-    echo "Activating floating license server."
     /opt/rstudio-pm/bin/license-manager license-server "$PPM_LICENSE_SERVER" --userspace
 elif test -f "$PPM_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/rspm/admin/licensing.html
     if [ "$(dirname "${PPM_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
         if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PPM_LICENSE_FILE_PATH."
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PPM_LICENSE_FILE_PATH." >&2
             exit 1
         fi
         cp "${PPM_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi
-    echo "Using license file at ${PPM_LICENSE_FILE_PATH}."
+    echo "Using license file at ${PPM_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in ${_license_dir}/."
+    echo "Detected a license file in ${_license_dir}/." >&2
 fi
 
 # ensure these cannot be inherited by child processes

--- a/package-manager/2025.12/scripts/startup.sh
+++ b/package-manager/2025.12/scripts/startup.sh
@@ -58,8 +58,6 @@ elif test -f "$PPM_LICENSE_FILE_PATH"; then
     echo "Using license file at ${PPM_LICENSE_FILE_PATH}."
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/."
-elif ls /home/rstudio-pm/.rstudio-pm/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in /home/rstudio-pm/.rstudio-pm/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/package-manager/2025.12/scripts/startup.sh
+++ b/package-manager/2025.12/scripts/startup.sh
@@ -46,7 +46,11 @@ if ! [ -z "$PPM_LICENSE" ]; then
 elif ! [ -z "$PPM_LICENSE_SERVER" ]; then
     /opt/rstudio-pm/bin/license-manager license-server "$PPM_LICENSE_SERVER" --userspace
 elif test -f "$PPM_LICENSE_FILE_PATH"; then
-    /opt/rstudio-pm/bin/license-manager activate-file "$PPM_LICENSE_FILE_PATH" --userspace
+    _tmp_lic=$(mktemp)
+    cp "${PPM_LICENSE_FILE_PATH}" "${_tmp_lic}"
+    mkdir -p /home/rstudio-pm/.rstudio-pm
+    mv "${_tmp_lic}" /home/rstudio-pm/.rstudio-pm/license.lic
+    chmod 0600 /home/rstudio-pm/.rstudio-pm/license.lic
 elif ls /var/lib/rstudio-pm/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in /var/lib/rstudio-pm/*.lic."
 elif ls /home/rstudio-pm/.rstudio-pm/*.lic >/dev/null 2>&1; then

--- a/package-manager/2025.12/scripts/startup.sh
+++ b/package-manager/2025.12/scripts/startup.sh
@@ -46,11 +46,13 @@ if ! [ -z "$PPM_LICENSE" ]; then
 elif ! [ -z "$PPM_LICENSE_SERVER" ]; then
     /opt/rstudio-pm/bin/license-manager license-server "$PPM_LICENSE_SERVER" --userspace
 elif test -f "$PPM_LICENSE_FILE_PATH"; then
+    # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
+    # https://docs.posit.co/rspm/admin/licensing.html
     _tmp_lic=$(mktemp)
     cp "${PPM_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    mkdir -p /home/rstudio-pm/.rstudio-pm
-    mv "${_tmp_lic}" /home/rstudio-pm/.rstudio-pm/license.lic
-    chmod 0600 /home/rstudio-pm/.rstudio-pm/license.lic
+    rm -f /var/lib/rstudio-pm/*.lic
+    mv "${_tmp_lic}" /var/lib/rstudio-pm/license.lic
+    chmod 0600 /var/lib/rstudio-pm/license.lic
 elif ls /var/lib/rstudio-pm/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in /var/lib/rstudio-pm/*.lic."
 elif ls /home/rstudio-pm/.rstudio-pm/*.lic >/dev/null 2>&1; then

--- a/package-manager/2026.04/scripts/startup.sh
+++ b/package-manager/2026.04/scripts/startup.sh
@@ -48,11 +48,10 @@ elif ! [ -z "$PPM_LICENSE_SERVER" ]; then
 elif test -f "$PPM_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/rspm/admin/licensing.html
-    _tmp_lic=$(mktemp)
-    cp "${PPM_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    rm -f /var/lib/rstudio-pm/*.lic
-    mv "${_tmp_lic}" /var/lib/rstudio-pm/license.lic
-    chmod 0600 /var/lib/rstudio-pm/license.lic
+    if [ "${PPM_LICENSE_FILE_PATH}" != "/var/lib/rstudio-pm/license.lic" ]; then
+        cp "${PPM_LICENSE_FILE_PATH}" /var/lib/rstudio-pm/license.lic
+        chmod 0600 /var/lib/rstudio-pm/license.lic
+    fi
 elif ls /var/lib/rstudio-pm/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in /var/lib/rstudio-pm/*.lic."
 elif ls /home/rstudio-pm/.rstudio-pm/*.lic >/dev/null 2>&1; then

--- a/package-manager/2026.04/scripts/startup.sh
+++ b/package-manager/2026.04/scripts/startup.sh
@@ -52,6 +52,10 @@ elif test -f "$PPM_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/rspm/admin/licensing.html
     if [ "$(dirname "${PPM_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        if mountpoint -q "${_license_dir}"; then
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PPM_LICENSE_FILE_PATH."
+            exit 1
+        fi
         cp "${PPM_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi

--- a/package-manager/2026.04/scripts/startup.sh
+++ b/package-manager/2026.04/scripts/startup.sh
@@ -40,22 +40,26 @@ PPM_LICENSE_FILE_PATH=${PPM_LICENSE_FILE_PATH:-$RSPM_LICENSE_FILE_PATH}
 
 # Activate License
 PPM_LICENSE_FILE_PATH=${PPM_LICENSE_FILE_PATH:-/etc/rstudio-pm/license.lic}
+_license_dir=/var/lib/rstudio-pm
 /opt/rstudio-pm/bin/license-manager initialize --userspace || true
 if ! [ -z "$PPM_LICENSE" ]; then
+    echo "Activating license key."
     /opt/rstudio-pm/bin/license-manager activate "$PPM_LICENSE" --userspace
 elif ! [ -z "$PPM_LICENSE_SERVER" ]; then
+    echo "Activating floating license server."
     /opt/rstudio-pm/bin/license-manager license-server "$PPM_LICENSE_SERVER" --userspace
 elif test -f "$PPM_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/rspm/admin/licensing.html
-    if [ "${PPM_LICENSE_FILE_PATH}" != "/var/lib/rstudio-pm/license.lic" ]; then
-        cp "${PPM_LICENSE_FILE_PATH}" /var/lib/rstudio-pm/license.lic
-        chmod 0600 /var/lib/rstudio-pm/license.lic
+    if [ "$(dirname "${PPM_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        cp "${PPM_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+        chmod 0600 "${_license_dir}/license.lic"
     fi
-elif ls /var/lib/rstudio-pm/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in /var/lib/rstudio-pm/*.lic."
+    echo "Using license file at ${PPM_LICENSE_FILE_PATH}."
+elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in ${_license_dir}/."
 elif ls /home/rstudio-pm/.rstudio-pm/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in /home/rstudio-pm/.rstudio-pm/*.lic."
+    echo "Detected a license file in /home/rstudio-pm/.rstudio-pm/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/package-manager/2026.04/scripts/startup.sh
+++ b/package-manager/2026.04/scripts/startup.sh
@@ -43,25 +43,23 @@ PPM_LICENSE_FILE_PATH=${PPM_LICENSE_FILE_PATH:-/etc/rstudio-pm/license.lic}
 _license_dir=/var/lib/rstudio-pm
 /opt/rstudio-pm/bin/license-manager initialize --userspace || true
 if ! [ -z "$PPM_LICENSE" ]; then
-    echo "Activating license key."
     /opt/rstudio-pm/bin/license-manager activate "$PPM_LICENSE" --userspace
 elif ! [ -z "$PPM_LICENSE_SERVER" ]; then
-    echo "Activating floating license server."
     /opt/rstudio-pm/bin/license-manager license-server "$PPM_LICENSE_SERVER" --userspace
 elif test -f "$PPM_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/rspm/admin/licensing.html
     if [ "$(dirname "${PPM_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
         if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PPM_LICENSE_FILE_PATH."
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PPM_LICENSE_FILE_PATH." >&2
             exit 1
         fi
         cp "${PPM_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi
-    echo "Using license file at ${PPM_LICENSE_FILE_PATH}."
+    echo "Using license file at ${PPM_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in ${_license_dir}/."
+    echo "Detected a license file in ${_license_dir}/." >&2
 fi
 
 # ensure these cannot be inherited by child processes

--- a/package-manager/2026.04/scripts/startup.sh
+++ b/package-manager/2026.04/scripts/startup.sh
@@ -58,8 +58,6 @@ elif test -f "$PPM_LICENSE_FILE_PATH"; then
     echo "Using license file at ${PPM_LICENSE_FILE_PATH}."
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/."
-elif ls /home/rstudio-pm/.rstudio-pm/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in /home/rstudio-pm/.rstudio-pm/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/package-manager/2026.04/scripts/startup.sh
+++ b/package-manager/2026.04/scripts/startup.sh
@@ -46,7 +46,11 @@ if ! [ -z "$PPM_LICENSE" ]; then
 elif ! [ -z "$PPM_LICENSE_SERVER" ]; then
     /opt/rstudio-pm/bin/license-manager license-server "$PPM_LICENSE_SERVER" --userspace
 elif test -f "$PPM_LICENSE_FILE_PATH"; then
-    /opt/rstudio-pm/bin/license-manager activate-file "$PPM_LICENSE_FILE_PATH" --userspace
+    _tmp_lic=$(mktemp)
+    cp "${PPM_LICENSE_FILE_PATH}" "${_tmp_lic}"
+    mkdir -p /home/rstudio-pm/.rstudio-pm
+    mv "${_tmp_lic}" /home/rstudio-pm/.rstudio-pm/license.lic
+    chmod 0600 /home/rstudio-pm/.rstudio-pm/license.lic
 elif ls /var/lib/rstudio-pm/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in /var/lib/rstudio-pm/*.lic."
 elif ls /home/rstudio-pm/.rstudio-pm/*.lic >/dev/null 2>&1; then

--- a/package-manager/2026.04/scripts/startup.sh
+++ b/package-manager/2026.04/scripts/startup.sh
@@ -46,11 +46,13 @@ if ! [ -z "$PPM_LICENSE" ]; then
 elif ! [ -z "$PPM_LICENSE_SERVER" ]; then
     /opt/rstudio-pm/bin/license-manager license-server "$PPM_LICENSE_SERVER" --userspace
 elif test -f "$PPM_LICENSE_FILE_PATH"; then
+    # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
+    # https://docs.posit.co/rspm/admin/licensing.html
     _tmp_lic=$(mktemp)
     cp "${PPM_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    mkdir -p /home/rstudio-pm/.rstudio-pm
-    mv "${_tmp_lic}" /home/rstudio-pm/.rstudio-pm/license.lic
-    chmod 0600 /home/rstudio-pm/.rstudio-pm/license.lic
+    rm -f /var/lib/rstudio-pm/*.lic
+    mv "${_tmp_lic}" /var/lib/rstudio-pm/license.lic
+    chmod 0600 /var/lib/rstudio-pm/license.lic
 elif ls /var/lib/rstudio-pm/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in /var/lib/rstudio-pm/*.lic."
 elif ls /home/rstudio-pm/.rstudio-pm/*.lic >/dev/null 2>&1; then

--- a/package-manager/2026.05/Containerfile.rhel10.min
+++ b/package-manager/2026.05/Containerfile.rhel10.min
@@ -1,5 +1,7 @@
-FROM registry.access.redhat.com/ubi10/ubi:10.2
-LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi:10.2"
+# latest is intentional: pulls security errata automatically on each rebuild,
+# equivalent to ubuntu:24.04 which also floats within the LTS release.
+FROM registry.access.redhat.com/ubi10/ubi:latest
+LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi:latest"
 
 ### ARG declarations ###
 ARG TARGETARCH

--- a/package-manager/2026.05/Containerfile.rhel10.min
+++ b/package-manager/2026.05/Containerfile.rhel10.min
@@ -1,5 +1,5 @@
-FROM registry.access.redhat.com/ubi10/ubi:latest
-LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi:latest"
+FROM registry.access.redhat.com/ubi10/ubi:10.2
+LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi:10.2"
 
 ### ARG declarations ###
 ARG TARGETARCH

--- a/package-manager/2026.05/Containerfile.rhel10.min
+++ b/package-manager/2026.05/Containerfile.rhel10.min
@@ -1,0 +1,53 @@
+FROM registry.access.redhat.com/ubi10/ubi:latest
+LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi:latest"
+
+### ARG declarations ###
+ARG TARGETARCH
+ARG PACKAGE_MANAGER_VERSION="2026.05.0"
+
+ENV PPM_LICENSE=""
+ENV PPM_LICENSE_SERVER=""
+ENV PPM_LICENSE_FILE_PATH=""
+ENV PPM_STARTUP_DEBUG=0
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+### Setup environment (upgrades packages + installs curl/tar/gnupg + configures Posit Pro repo) ###
+RUN dnf upgrade -yq && \
+    dnf install -yq --allowerasing \
+        curl \
+        ca-certificates \
+        findutils \
+        gnupg \
+        tar && \
+    bash -c "$(curl -1fsSL 'https://dl.posit.co/public/pro/setup.rpm.sh')" && \
+    dnf clean all -yq
+
+### Install dnf packages ###
+COPY package-manager/2026.05/deps/rhel-10_packages.txt /tmp/packages.txt
+RUN xargs -a /tmp/packages.txt dnf install -yq && \
+    dnf clean all -yq
+
+
+
+### Install Package Manager 2026.05.0 ###
+COPY --chmod=0755 package-manager/2026.05/scripts/install_package_manager.rhel10.sh /tmp/install_package_manager.sh
+RUN \
+    /tmp/install_package_manager.sh \
+    && rm -f /tmp/install_package_manager.sh
+
+### Add startup.sh script ###
+COPY --chmod=0775 package-manager/2026.05/scripts/startup.sh /usr/local/bin/startup.sh
+RUN mkdir -p /var/run/rstudio-pm \
+    && chmod +x /usr/local/bin/startup.sh \
+    && chown rstudio-pm:rstudio-pm /usr/local/bin/startup.sh \
+    && chown -R rstudio-pm:rstudio-pm /var/run/rstudio-pm
+
+USER rstudio-pm
+
+RUN echo "source <(rspm completion bash)" >> ~/.bashrc
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD curl -fsS http://localhost:4242/__ping__ || exit 1
+
+CMD ["/usr/local/bin/startup.sh"]

--- a/package-manager/2026.05/Containerfile.rhel10.std
+++ b/package-manager/2026.05/Containerfile.rhel10.std
@@ -8,8 +8,8 @@ RUN uv python install 3.14.5
 RUN mv /opt/python/cpython-3.14.5-linux-*/ /opt/python/3.14.5
 
 
-FROM registry.access.redhat.com/ubi10/ubi:latest
-LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi:latest"
+FROM registry.access.redhat.com/ubi10/ubi:10.2
+LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi:10.2"
 
 ### ARG declarations ###
 ARG TARGETARCH

--- a/package-manager/2026.05/Containerfile.rhel10.std
+++ b/package-manager/2026.05/Containerfile.rhel10.std
@@ -1,0 +1,74 @@
+# Build Python using uv in a separate stage
+FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
+
+ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
+ENV UV_PYTHON_INSTALL_DIR=/opt/python
+ENV UV_PYTHON_PREFERENCE=only-managed
+RUN uv python install 3.14.5
+RUN mv /opt/python/cpython-3.14.5-linux-*/ /opt/python/3.14.5
+
+
+FROM registry.access.redhat.com/ubi10/ubi:latest
+LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi:latest"
+
+### ARG declarations ###
+ARG TARGETARCH
+ARG PACKAGE_MANAGER_VERSION="2026.05.0"
+
+ENV PPM_LICENSE=""
+ENV PPM_LICENSE_SERVER=""
+ENV PPM_LICENSE_FILE_PATH=""
+ENV PPM_STARTUP_DEBUG=0
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+### Setup environment (upgrades packages + installs curl/tar/gnupg + configures Posit Pro repo) ###
+RUN dnf upgrade -yq && \
+    dnf install -yq --allowerasing \
+        curl \
+        ca-certificates \
+        findutils \
+        gnupg \
+        tar && \
+    bash -c "$(curl -1fsSL 'https://dl.posit.co/public/pro/setup.rpm.sh')" && \
+    dnf clean all -yq
+
+### Install dnf packages ###
+COPY package-manager/2026.05/deps/rhel-10_packages.txt /tmp/packages.txt
+RUN xargs -a /tmp/packages.txt dnf install -yq && \
+    dnf clean all -yq
+
+### Install Python from previous stage ###
+COPY --from=python-builder /opt/python /opt/python
+
+### Install Python packages ###
+COPY package-manager/2026.05/deps/python_requirements.txt /tmp/requirements.txt
+RUN /opt/python/3.14.5/bin/pip install --no-cache-dir --upgrade --break-system-packages \
+        -r /tmp/requirements.txt && \
+    rm -f /tmp/requirements.txt
+
+### Install R ###
+RUN RUN_UNATTENDED=1 R_VERSION=4.6.0 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \
+    find . -type f -name '[rR]-4.6.0.*\.(deb|rpm)' -delete
+
+### Install Package Manager 2026.05.0 ###
+COPY --chmod=0755 package-manager/2026.05/scripts/install_package_manager.rhel10.sh /tmp/install_package_manager.sh
+RUN PYTHON_VERSION=3.14.5 R_VERSION=4.6.0 \
+    /tmp/install_package_manager.sh \
+    && rm -f /tmp/install_package_manager.sh
+
+### Add startup.sh script ###
+COPY --chmod=0775 package-manager/2026.05/scripts/startup.sh /usr/local/bin/startup.sh
+RUN mkdir -p /var/run/rstudio-pm \
+    && chmod +x /usr/local/bin/startup.sh \
+    && chown rstudio-pm:rstudio-pm /usr/local/bin/startup.sh \
+    && chown -R rstudio-pm:rstudio-pm /var/run/rstudio-pm
+
+USER rstudio-pm
+
+RUN echo "source <(rspm completion bash)" >> ~/.bashrc
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD curl -fsS http://localhost:4242/__ping__ || exit 1
+
+CMD ["/usr/local/bin/startup.sh"]

--- a/package-manager/2026.05/Containerfile.rhel10.std
+++ b/package-manager/2026.05/Containerfile.rhel10.std
@@ -8,8 +8,10 @@ RUN uv python install 3.14.5
 RUN mv /opt/python/cpython-3.14.5-linux-*/ /opt/python/3.14.5
 
 
-FROM registry.access.redhat.com/ubi10/ubi:10.2
-LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi:10.2"
+# latest is intentional: pulls security errata automatically on each rebuild,
+# equivalent to ubuntu:24.04 which also floats within the LTS release.
+FROM registry.access.redhat.com/ubi10/ubi:latest
+LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi:latest"
 
 ### ARG declarations ###
 ARG TARGETARCH

--- a/package-manager/2026.05/deps/rhel-10_packages.txt
+++ b/package-manager/2026.05/deps/rhel-10_packages.txt
@@ -1,0 +1,2 @@
+glibc
+openssl

--- a/package-manager/2026.05/scripts/install_package_manager.rhel10.sh
+++ b/package-manager/2026.05/scripts/install_package_manager.rhel10.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -eo pipefail
+
+# Output delimiter
+d="===="
+
+echo "$d Install Posit Package Manager 2026.05.0 $d"
+
+RSTUDIO_INSTALL_NO_LICENSE_INITIALIZATION=1 dnf install -yq rstudio-pm-2026.05.0
+
+PPM_CONFIG_FILE="/etc/rstudio-pm/rstudio-pm.gcfg"
+
+if [ -n "$R_VERSION" ] && [ -n "$PYTHON_VERSION" ]
+then
+    # The default rstudio-pm.gcfg has an RVersion section already, let's comment that out.
+    sed -i 's/RVersion =/;RVersion =/' $PPM_CONFIG_FILE
+
+    echo "$d Setting R and Python version configuration $d"
+    sed -i "0,/.*RVersion.*/s||RVersion = /opt/R/$R_VERSION\nPythonVersion = /opt/python/$PYTHON_VERSION/bin/python|" $PPM_CONFIG_FILE
+
+    # Git package builds require R or Python and would otherwise fail because
+    # Package Manager's process sandbox is unavailable in containers. Allow
+    # unsandboxed Git builds so they work out of the box. This is gated on
+    # R_VERSION/PYTHON_VERSION being set, which is true only for the Standard
+    # variant -- Minimal users extending the image opt in by setting the
+    # option themselves once they install R or Python.
+    echo "$d Allowing unsandboxed Git builds $d"
+    if grep -q '^\[Git\]' $PPM_CONFIG_FILE; then
+        sed -i '/^\[Git\]/a AllowUnsandboxedGitBuilds = true' $PPM_CONFIG_FILE
+    else
+        printf '\n[Git]\nAllowUnsandboxedGitBuilds = true\n' >> $PPM_CONFIG_FILE
+    fi
+else
+    echo "$d No R or Python version provided $d"
+fi
+
+# clean up
+dnf clean all -yq

--- a/package-manager/2026.05/scripts/startup.sh
+++ b/package-manager/2026.05/scripts/startup.sh
@@ -48,11 +48,10 @@ elif ! [ -z "$PPM_LICENSE_SERVER" ]; then
 elif test -f "$PPM_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/rspm/admin/licensing.html
-    _tmp_lic=$(mktemp)
-    cp "${PPM_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    rm -f /var/lib/rstudio-pm/*.lic
-    mv "${_tmp_lic}" /var/lib/rstudio-pm/license.lic
-    chmod 0600 /var/lib/rstudio-pm/license.lic
+    if [ "${PPM_LICENSE_FILE_PATH}" != "/var/lib/rstudio-pm/license.lic" ]; then
+        cp "${PPM_LICENSE_FILE_PATH}" /var/lib/rstudio-pm/license.lic
+        chmod 0600 /var/lib/rstudio-pm/license.lic
+    fi
 elif ls /var/lib/rstudio-pm/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in /var/lib/rstudio-pm/*.lic."
 elif ls /home/rstudio-pm/.rstudio-pm/*.lic >/dev/null 2>&1; then

--- a/package-manager/2026.05/scripts/startup.sh
+++ b/package-manager/2026.05/scripts/startup.sh
@@ -52,6 +52,10 @@ elif test -f "$PPM_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/rspm/admin/licensing.html
     if [ "$(dirname "${PPM_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        if mountpoint -q "${_license_dir}"; then
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PPM_LICENSE_FILE_PATH."
+            exit 1
+        fi
         cp "${PPM_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi

--- a/package-manager/2026.05/scripts/startup.sh
+++ b/package-manager/2026.05/scripts/startup.sh
@@ -40,22 +40,26 @@ PPM_LICENSE_FILE_PATH=${PPM_LICENSE_FILE_PATH:-$RSPM_LICENSE_FILE_PATH}
 
 # Activate License
 PPM_LICENSE_FILE_PATH=${PPM_LICENSE_FILE_PATH:-/etc/rstudio-pm/license.lic}
+_license_dir=/var/lib/rstudio-pm
 /opt/rstudio-pm/bin/license-manager initialize --userspace || true
 if ! [ -z "$PPM_LICENSE" ]; then
+    echo "Activating license key."
     /opt/rstudio-pm/bin/license-manager activate "$PPM_LICENSE" --userspace
 elif ! [ -z "$PPM_LICENSE_SERVER" ]; then
+    echo "Activating floating license server."
     /opt/rstudio-pm/bin/license-manager license-server "$PPM_LICENSE_SERVER" --userspace
 elif test -f "$PPM_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/rspm/admin/licensing.html
-    if [ "${PPM_LICENSE_FILE_PATH}" != "/var/lib/rstudio-pm/license.lic" ]; then
-        cp "${PPM_LICENSE_FILE_PATH}" /var/lib/rstudio-pm/license.lic
-        chmod 0600 /var/lib/rstudio-pm/license.lic
+    if [ "$(dirname "${PPM_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        cp "${PPM_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+        chmod 0600 "${_license_dir}/license.lic"
     fi
-elif ls /var/lib/rstudio-pm/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in /var/lib/rstudio-pm/*.lic."
+    echo "Using license file at ${PPM_LICENSE_FILE_PATH}."
+elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in ${_license_dir}/."
 elif ls /home/rstudio-pm/.rstudio-pm/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in /home/rstudio-pm/.rstudio-pm/*.lic."
+    echo "Detected a license file in /home/rstudio-pm/.rstudio-pm/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/package-manager/2026.05/scripts/startup.sh
+++ b/package-manager/2026.05/scripts/startup.sh
@@ -43,25 +43,23 @@ PPM_LICENSE_FILE_PATH=${PPM_LICENSE_FILE_PATH:-/etc/rstudio-pm/license.lic}
 _license_dir=/var/lib/rstudio-pm
 /opt/rstudio-pm/bin/license-manager initialize --userspace || true
 if ! [ -z "$PPM_LICENSE" ]; then
-    echo "Activating license key."
     /opt/rstudio-pm/bin/license-manager activate "$PPM_LICENSE" --userspace
 elif ! [ -z "$PPM_LICENSE_SERVER" ]; then
-    echo "Activating floating license server."
     /opt/rstudio-pm/bin/license-manager license-server "$PPM_LICENSE_SERVER" --userspace
 elif test -f "$PPM_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/rspm/admin/licensing.html
     if [ "$(dirname "${PPM_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
         if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PPM_LICENSE_FILE_PATH."
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PPM_LICENSE_FILE_PATH." >&2
             exit 1
         fi
         cp "${PPM_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi
-    echo "Using license file at ${PPM_LICENSE_FILE_PATH}."
+    echo "Using license file at ${PPM_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in ${_license_dir}/."
+    echo "Detected a license file in ${_license_dir}/." >&2
 fi
 
 # ensure these cannot be inherited by child processes

--- a/package-manager/2026.05/scripts/startup.sh
+++ b/package-manager/2026.05/scripts/startup.sh
@@ -58,8 +58,6 @@ elif test -f "$PPM_LICENSE_FILE_PATH"; then
     echo "Using license file at ${PPM_LICENSE_FILE_PATH}."
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/."
-elif ls /home/rstudio-pm/.rstudio-pm/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in /home/rstudio-pm/.rstudio-pm/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/package-manager/2026.05/scripts/startup.sh
+++ b/package-manager/2026.05/scripts/startup.sh
@@ -46,7 +46,11 @@ if ! [ -z "$PPM_LICENSE" ]; then
 elif ! [ -z "$PPM_LICENSE_SERVER" ]; then
     /opt/rstudio-pm/bin/license-manager license-server "$PPM_LICENSE_SERVER" --userspace
 elif test -f "$PPM_LICENSE_FILE_PATH"; then
-    /opt/rstudio-pm/bin/license-manager activate-file "$PPM_LICENSE_FILE_PATH" --userspace
+    _tmp_lic=$(mktemp)
+    cp "${PPM_LICENSE_FILE_PATH}" "${_tmp_lic}"
+    mkdir -p /home/rstudio-pm/.rstudio-pm
+    mv "${_tmp_lic}" /home/rstudio-pm/.rstudio-pm/license.lic
+    chmod 0600 /home/rstudio-pm/.rstudio-pm/license.lic
 elif ls /var/lib/rstudio-pm/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in /var/lib/rstudio-pm/*.lic."
 elif ls /home/rstudio-pm/.rstudio-pm/*.lic >/dev/null 2>&1; then

--- a/package-manager/2026.05/scripts/startup.sh
+++ b/package-manager/2026.05/scripts/startup.sh
@@ -46,11 +46,13 @@ if ! [ -z "$PPM_LICENSE" ]; then
 elif ! [ -z "$PPM_LICENSE_SERVER" ]; then
     /opt/rstudio-pm/bin/license-manager license-server "$PPM_LICENSE_SERVER" --userspace
 elif test -f "$PPM_LICENSE_FILE_PATH"; then
+    # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
+    # https://docs.posit.co/rspm/admin/licensing.html
     _tmp_lic=$(mktemp)
     cp "${PPM_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    mkdir -p /home/rstudio-pm/.rstudio-pm
-    mv "${_tmp_lic}" /home/rstudio-pm/.rstudio-pm/license.lic
-    chmod 0600 /home/rstudio-pm/.rstudio-pm/license.lic
+    rm -f /var/lib/rstudio-pm/*.lic
+    mv "${_tmp_lic}" /var/lib/rstudio-pm/license.lic
+    chmod 0600 /var/lib/rstudio-pm/license.lic
 elif ls /var/lib/rstudio-pm/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in /var/lib/rstudio-pm/*.lic."
 elif ls /home/rstudio-pm/.rstudio-pm/*.lic >/dev/null 2>&1; then

--- a/package-manager/2026.05/test/goss.yaml
+++ b/package-manager/2026.05/test/goss.yaml
@@ -1,13 +1,13 @@
 user:
   rstudio-pm:
     exists: true
-    uid: 999
-    gid: 999
+    uid: {{ if eq .Env.IMAGE_OS_FAMILY "rhel" }}998{{ else }}999{{ end }}
+    gid: {{ if eq .Env.IMAGE_OS_FAMILY "rhel" }}997{{ else }}999{{ end }}
 
 group:
   rstudio-pm:
     exists: true
-    gid: 999
+    gid: {{ if eq .Env.IMAGE_OS_FAMILY "rhel" }}997{{ else }}999{{ end }}
 
 package:
   rstudio-pm:

--- a/package-manager/template/Containerfile.rhel10.jinja2
+++ b/package-manager/template/Containerfile.rhel10.jinja2
@@ -12,8 +12,10 @@ Bakery handles bootstrapping the files into template rendering.
 
 {% endif -%}
 
-FROM registry.access.redhat.com/ubi10/ubi:10.2
-LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi:10.2"
+# latest is intentional: pulls security errata automatically on each rebuild,
+# equivalent to ubuntu:24.04 which also floats within the LTS release.
+FROM registry.access.redhat.com/ubi10/ubi:latest
+LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi:latest"
 
 ### ARG declarations ###
 ARG TARGETARCH

--- a/package-manager/template/Containerfile.rhel10.jinja2
+++ b/package-manager/template/Containerfile.rhel10.jinja2
@@ -12,8 +12,8 @@ Bakery handles bootstrapping the files into template rendering.
 
 {% endif -%}
 
-FROM registry.access.redhat.com/ubi10/ubi:latest
-LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi:latest"
+FROM registry.access.redhat.com/ubi10/ubi:10.2
+LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi:10.2"
 
 ### ARG declarations ###
 ARG TARGETARCH

--- a/package-manager/template/Containerfile.rhel10.jinja2
+++ b/package-manager/template/Containerfile.rhel10.jinja2
@@ -1,0 +1,68 @@
+{#-
+Below are imports for Bakery's macros. If any are unneeded, they can be removed.
+Bakery handles bootstrapping the files into template rendering.
+-#}
+{%- import "dnf.j2" as dnf -%}
+{%- import "python.j2" as python -%}
+{%- import "r.j2" as r -%}
+
+{%- if Image.Variant != "Minimal" -%}
+# Build Python using uv in a separate stage
+{{ python.build_stage(Dependencies.python) }}
+
+{% endif -%}
+
+FROM registry.access.redhat.com/ubi10/ubi:latest
+LABEL org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi:latest"
+
+### ARG declarations ###
+ARG TARGETARCH
+ARG PACKAGE_MANAGER_VERSION="{{ Image.Version }}"
+
+ENV PPM_LICENSE=""
+ENV PPM_LICENSE_SERVER=""
+ENV PPM_LICENSE_FILE_PATH=""
+ENV PPM_STARTUP_DEBUG=0
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+### Setup environment (upgrades packages + installs curl/tar/gnupg + configures Posit Pro repo) ###
+{{ dnf.run_setup() }}
+
+### Install dnf packages ###
+COPY {{ Path.Version }}/deps/rhel-10_packages.txt /tmp/packages.txt
+{{ dnf.run_install(files = '/tmp/packages.txt') }}
+
+{% if not Image.Variant == "Minimal" -%}
+### Install Python from previous stage ###
+{{ python.copy_from_build_stage() }}
+
+### Install Python packages ###
+COPY {{ Path.Version }}/deps/python_requirements.txt /tmp/requirements.txt
+{{ python.run_install_packages(Dependencies.python, requirements_file='/tmp/requirements.txt') }}
+
+### Install R ###
+{{ r.run_install(Dependencies.R) }}
+{%- endif %}
+
+### Install Package Manager {{ Image.Version }} ###
+COPY --chmod=0755 {{ Path.Version }}/scripts/install_package_manager.rhel10.sh /tmp/install_package_manager.sh
+RUN {% if Image.Variant != "Minimal" %}PYTHON_VERSION={{ Dependencies.python.0 }} R_VERSION={{ Dependencies.R.0 }} {% endif %}{% if Image.DownloadURL is defined %}DOWNLOAD_URL="{{ Image.DownloadURL }}" {% endif %}\
+    /tmp/install_package_manager.sh \
+    && rm -f /tmp/install_package_manager.sh
+
+### Add startup.sh script ###
+COPY --chmod=0775 {{ Path.Version }}/scripts/startup.sh /usr/local/bin/startup.sh
+RUN mkdir -p /var/run/rstudio-pm \
+    && chmod +x /usr/local/bin/startup.sh \
+    && chown rstudio-pm:rstudio-pm /usr/local/bin/startup.sh \
+    && chown -R rstudio-pm:rstudio-pm /var/run/rstudio-pm
+
+USER rstudio-pm
+
+RUN echo "source <(rspm completion bash)" >> ~/.bashrc
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD curl -fsS http://localhost:4242/__ping__ || exit 1
+
+CMD ["/usr/local/bin/startup.sh"]

--- a/package-manager/template/deps/rhel-10_packages.txt.jinja2
+++ b/package-manager/template/deps/rhel-10_packages.txt.jinja2
@@ -1,0 +1,2 @@
+glibc
+openssl

--- a/package-manager/template/scripts/install_package_manager.rhel10.sh.jinja2
+++ b/package-manager/template/scripts/install_package_manager.rhel10.sh.jinja2
@@ -1,0 +1,56 @@
+{#-
+Below are imports for Bakery's macros. If any are unneeded, they can be removed.
+Bakery handles bootstrapping the files into template rendering.
+-#}
+{%- import "python.j2" as python -%}
+{%- import "r.j2" as r -%}
+#!/bin/bash
+set -eo pipefail
+
+# Output delimiter
+d="===="
+
+{% if Image.IsDevelopmentVersion -%}
+echo "$d Fetching Posit Package Manager {{ Image.Version }} package $d"
+
+# fetch dev build rpm package
+curl -fsSL "$DOWNLOAD_URL" -o /tmp/rstudio-pm.rpm
+
+echo "$d Install Posit Package Manager {{ Image.Version }} $d"
+RSTUDIO_INSTALL_NO_LICENSE_INITIALIZATION=1 dnf install -yq /tmp/rstudio-pm.rpm
+
+rm -f /tmp/rstudio-pm.rpm
+{%- else -%}
+echo "$d Install Posit Package Manager {{ Image.Version }} $d"
+
+RSTUDIO_INSTALL_NO_LICENSE_INITIALIZATION=1 dnf install -yq rstudio-pm-{{ Image.Version }}
+{%- endif %}
+
+PPM_CONFIG_FILE="/etc/rstudio-pm/rstudio-pm.gcfg"
+
+if [ -n "$R_VERSION" ] && [ -n "$PYTHON_VERSION" ]
+then
+    # The default rstudio-pm.gcfg has an RVersion section already, let's comment that out.
+    sed -i 's/RVersion =/;RVersion =/' $PPM_CONFIG_FILE
+
+    echo "$d Setting R and Python version configuration $d"
+    sed -i "0,/.*RVersion.*/s||RVersion = {{ r.get_version_directory("$R_VERSION") }}\nPythonVersion = {{ python.get_version_directory("$PYTHON_VERSION") }}/bin/python|" $PPM_CONFIG_FILE
+
+    # Git package builds require R or Python and would otherwise fail because
+    # Package Manager's process sandbox is unavailable in containers. Allow
+    # unsandboxed Git builds so they work out of the box. This is gated on
+    # R_VERSION/PYTHON_VERSION being set, which is true only for the Standard
+    # variant -- Minimal users extending the image opt in by setting the
+    # option themselves once they install R or Python.
+    echo "$d Allowing unsandboxed Git builds $d"
+    if grep -q '^\[Git\]' $PPM_CONFIG_FILE; then
+        sed -i '/^\[Git\]/a AllowUnsandboxedGitBuilds = true' $PPM_CONFIG_FILE
+    else
+        printf '\n[Git]\nAllowUnsandboxedGitBuilds = true\n' >> $PPM_CONFIG_FILE
+    fi
+else
+    echo "$d No R or Python version provided $d"
+fi
+
+# clean up
+dnf clean all -yq

--- a/package-manager/template/scripts/startup.sh.jinja2
+++ b/package-manager/template/scripts/startup.sh.jinja2
@@ -48,11 +48,10 @@ elif ! [ -z "$PPM_LICENSE_SERVER" ]; then
 elif test -f "$PPM_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/rspm/admin/licensing.html
-    _tmp_lic=$(mktemp)
-    cp "${PPM_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    rm -f /var/lib/rstudio-pm/*.lic
-    mv "${_tmp_lic}" /var/lib/rstudio-pm/license.lic
-    chmod 0600 /var/lib/rstudio-pm/license.lic
+    if [ "${PPM_LICENSE_FILE_PATH}" != "/var/lib/rstudio-pm/license.lic" ]; then
+        cp "${PPM_LICENSE_FILE_PATH}" /var/lib/rstudio-pm/license.lic
+        chmod 0600 /var/lib/rstudio-pm/license.lic
+    fi
 elif ls /var/lib/rstudio-pm/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in /var/lib/rstudio-pm/*.lic."
 elif ls /home/rstudio-pm/.rstudio-pm/*.lic >/dev/null 2>&1; then

--- a/package-manager/template/scripts/startup.sh.jinja2
+++ b/package-manager/template/scripts/startup.sh.jinja2
@@ -52,6 +52,10 @@ elif test -f "$PPM_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/rspm/admin/licensing.html
     if [ "$(dirname "${PPM_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        if mountpoint -q "${_license_dir}"; then
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PPM_LICENSE_FILE_PATH."
+            exit 1
+        fi
         cp "${PPM_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi

--- a/package-manager/template/scripts/startup.sh.jinja2
+++ b/package-manager/template/scripts/startup.sh.jinja2
@@ -40,22 +40,26 @@ PPM_LICENSE_FILE_PATH=${PPM_LICENSE_FILE_PATH:-$RSPM_LICENSE_FILE_PATH}
 
 # Activate License
 PPM_LICENSE_FILE_PATH=${PPM_LICENSE_FILE_PATH:-/etc/rstudio-pm/license.lic}
+_license_dir=/var/lib/rstudio-pm
 /opt/rstudio-pm/bin/license-manager initialize --userspace || true
 if ! [ -z "$PPM_LICENSE" ]; then
+    echo "Activating license key."
     /opt/rstudio-pm/bin/license-manager activate "$PPM_LICENSE" --userspace
 elif ! [ -z "$PPM_LICENSE_SERVER" ]; then
+    echo "Activating floating license server."
     /opt/rstudio-pm/bin/license-manager license-server "$PPM_LICENSE_SERVER" --userspace
 elif test -f "$PPM_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/rspm/admin/licensing.html
-    if [ "${PPM_LICENSE_FILE_PATH}" != "/var/lib/rstudio-pm/license.lic" ]; then
-        cp "${PPM_LICENSE_FILE_PATH}" /var/lib/rstudio-pm/license.lic
-        chmod 0600 /var/lib/rstudio-pm/license.lic
+    if [ "$(dirname "${PPM_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        cp "${PPM_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+        chmod 0600 "${_license_dir}/license.lic"
     fi
-elif ls /var/lib/rstudio-pm/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in /var/lib/rstudio-pm/*.lic."
+    echo "Using license file at ${PPM_LICENSE_FILE_PATH}."
+elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in ${_license_dir}/."
 elif ls /home/rstudio-pm/.rstudio-pm/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in /home/rstudio-pm/.rstudio-pm/*.lic."
+    echo "Detected a license file in /home/rstudio-pm/.rstudio-pm/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/package-manager/template/scripts/startup.sh.jinja2
+++ b/package-manager/template/scripts/startup.sh.jinja2
@@ -43,25 +43,23 @@ PPM_LICENSE_FILE_PATH=${PPM_LICENSE_FILE_PATH:-/etc/rstudio-pm/license.lic}
 _license_dir=/var/lib/rstudio-pm
 /opt/rstudio-pm/bin/license-manager initialize --userspace || true
 if ! [ -z "$PPM_LICENSE" ]; then
-    echo "Activating license key."
     /opt/rstudio-pm/bin/license-manager activate "$PPM_LICENSE" --userspace
 elif ! [ -z "$PPM_LICENSE_SERVER" ]; then
-    echo "Activating floating license server."
     /opt/rstudio-pm/bin/license-manager license-server "$PPM_LICENSE_SERVER" --userspace
 elif test -f "$PPM_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/rspm/admin/licensing.html
     if [ "$(dirname "${PPM_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
         if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PPM_LICENSE_FILE_PATH."
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PPM_LICENSE_FILE_PATH." >&2
             exit 1
         fi
         cp "${PPM_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi
-    echo "Using license file at ${PPM_LICENSE_FILE_PATH}."
+    echo "Using license file at ${PPM_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in ${_license_dir}/."
+    echo "Detected a license file in ${_license_dir}/." >&2
 fi
 
 # ensure these cannot be inherited by child processes

--- a/package-manager/template/scripts/startup.sh.jinja2
+++ b/package-manager/template/scripts/startup.sh.jinja2
@@ -58,8 +58,6 @@ elif test -f "$PPM_LICENSE_FILE_PATH"; then
     echo "Using license file at ${PPM_LICENSE_FILE_PATH}."
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/."
-elif ls /home/rstudio-pm/.rstudio-pm/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in /home/rstudio-pm/.rstudio-pm/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/package-manager/template/scripts/startup.sh.jinja2
+++ b/package-manager/template/scripts/startup.sh.jinja2
@@ -46,7 +46,11 @@ if ! [ -z "$PPM_LICENSE" ]; then
 elif ! [ -z "$PPM_LICENSE_SERVER" ]; then
     /opt/rstudio-pm/bin/license-manager license-server "$PPM_LICENSE_SERVER" --userspace
 elif test -f "$PPM_LICENSE_FILE_PATH"; then
-    /opt/rstudio-pm/bin/license-manager activate-file "$PPM_LICENSE_FILE_PATH" --userspace
+    _tmp_lic=$(mktemp)
+    cp "${PPM_LICENSE_FILE_PATH}" "${_tmp_lic}"
+    mkdir -p /home/rstudio-pm/.rstudio-pm
+    mv "${_tmp_lic}" /home/rstudio-pm/.rstudio-pm/license.lic
+    chmod 0600 /home/rstudio-pm/.rstudio-pm/license.lic
 elif ls /var/lib/rstudio-pm/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in /var/lib/rstudio-pm/*.lic."
 elif ls /home/rstudio-pm/.rstudio-pm/*.lic >/dev/null 2>&1; then

--- a/package-manager/template/scripts/startup.sh.jinja2
+++ b/package-manager/template/scripts/startup.sh.jinja2
@@ -46,11 +46,13 @@ if ! [ -z "$PPM_LICENSE" ]; then
 elif ! [ -z "$PPM_LICENSE_SERVER" ]; then
     /opt/rstudio-pm/bin/license-manager license-server "$PPM_LICENSE_SERVER" --userspace
 elif test -f "$PPM_LICENSE_FILE_PATH"; then
+    # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
+    # https://docs.posit.co/rspm/admin/licensing.html
     _tmp_lic=$(mktemp)
     cp "${PPM_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    mkdir -p /home/rstudio-pm/.rstudio-pm
-    mv "${_tmp_lic}" /home/rstudio-pm/.rstudio-pm/license.lic
-    chmod 0600 /home/rstudio-pm/.rstudio-pm/license.lic
+    rm -f /var/lib/rstudio-pm/*.lic
+    mv "${_tmp_lic}" /var/lib/rstudio-pm/license.lic
+    chmod 0600 /var/lib/rstudio-pm/license.lic
 elif ls /var/lib/rstudio-pm/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in /var/lib/rstudio-pm/*.lic."
 elif ls /home/rstudio-pm/.rstudio-pm/*.lic >/dev/null 2>&1; then

--- a/package-manager/template/test/goss.yaml.jinja2
+++ b/package-manager/template/test/goss.yaml.jinja2
@@ -12,13 +12,13 @@ Bakery handles bootstrapping the files into template rendering.
 user:
   rstudio-pm:
     exists: true
-    uid: 999
-    gid: 999
+    uid: {% raw %}{{ if eq .Env.IMAGE_OS_FAMILY "rhel" }}998{{ else }}999{{ end }}{% endraw %}
+    gid: {% raw %}{{ if eq .Env.IMAGE_OS_FAMILY "rhel" }}997{{ else }}999{{ end }}{% endraw %}
 
 group:
   rstudio-pm:
     exists: true
-    gid: 999
+    gid: {% raw %}{{ if eq .Env.IMAGE_OS_FAMILY "rhel" }}997{{ else }}999{{ end }}{% endraw %}
 
 package:
   rstudio-pm:


### PR DESCRIPTION
Replace `license-manager activate-file --userspace` with a direct file
copy to `/home/rstudio-pm/.rstudio-pm/license.lic`, where Package
Manager reads `*.lic` files natively.

Copying the license file directly is the approach recommended by the
product teams. It avoids the activation/deactivation cycle entirely,
eliminating the risk of leaking activation slots when a container exits
ungracefully. An alternative would be to keep `activate-file
--userspace` (which was introduced in 2022 specifically for non-root
use), but the direct-copy approach is preferred per product team
guidance (rstudio/rstudio-docker-products#734).

The `USER rstudio-pm` instruction in the Containerfile means
`startup.sh` already runs as `rstudio-pm`, so no `chown` is needed
after the copy. A temp file is used before the `mv` so the source is
safely read even if `PPM_LICENSE_FILE_PATH` points inside the target
directory.

Mirrors the fix applied to `rstudio-docker-products` in July 2025
(commit 66470dc). See also the equivalent fix for Connect:

- https://github.com/posit-dev/images-connect/pull/122