### PR TITLE
Re-render: add uv self update before Python install

### DIFF
--- a/package-manager/2025.04/Containerfile.ubuntu2204.std
+++ b/package-manager/2025.04/Containerfile.ubuntu2204.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.12.11
+RUN uv self update && uv python install 3.12.11
 RUN mv /opt/python/cpython-3.12.11-linux-*/ /opt/python/3.12.11
 
 

--- a/package-manager/2025.04/Containerfile.ubuntu2404.std
+++ b/package-manager/2025.04/Containerfile.ubuntu2404.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.12.11
+RUN uv self update && uv python install 3.12.11
 RUN mv /opt/python/cpython-3.12.11-linux-*/ /opt/python/3.12.11
 
 

--- a/package-manager/2025.09/Containerfile.ubuntu2204.std
+++ b/package-manager/2025.09/Containerfile.ubuntu2204.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.13.7
+RUN uv self update && uv python install 3.13.7
 RUN mv /opt/python/cpython-3.13.7-linux-*/ /opt/python/3.13.7
 
 

--- a/package-manager/2025.09/Containerfile.ubuntu2404.std
+++ b/package-manager/2025.09/Containerfile.ubuntu2404.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.13.7
+RUN uv self update && uv python install 3.13.7
 RUN mv /opt/python/cpython-3.13.7-linux-*/ /opt/python/3.13.7
 
 

--- a/package-manager/2025.12/Containerfile.ubuntu2204.std
+++ b/package-manager/2025.12/Containerfile.ubuntu2204.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.14.2
+RUN uv self update && uv python install 3.14.2
 RUN mv /opt/python/cpython-3.14.2-linux-*/ /opt/python/3.14.2
 
 

--- a/package-manager/2025.12/Containerfile.ubuntu2404.std
+++ b/package-manager/2025.12/Containerfile.ubuntu2404.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.14.2
+RUN uv self update && uv python install 3.14.2
 RUN mv /opt/python/cpython-3.14.2-linux-*/ /opt/python/3.14.2
 
 

--- a/package-manager/2026.04/Containerfile.ubuntu2204.std
+++ b/package-manager/2026.04/Containerfile.ubuntu2204.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.14.4
+RUN uv self update && uv python install 3.14.4
 RUN mv /opt/python/cpython-3.14.4-linux-*/ /opt/python/3.14.4
 
 

--- a/package-manager/2026.04/Containerfile.ubuntu2404.std
+++ b/package-manager/2026.04/Containerfile.ubuntu2404.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.14.4
+RUN uv self update && uv python install 3.14.4
 RUN mv /opt/python/cpython-3.14.4-linux-*/ /opt/python/3.14.4
 
 

--- a/package-manager/2026.05/Containerfile.ubuntu2204.std
+++ b/package-manager/2026.05/Containerfile.ubuntu2204.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.14.5
+RUN uv self update && uv python install 3.14.5
 RUN mv /opt/python/cpython-3.14.5-linux-*/ /opt/python/3.14.5
 
 

--- a/package-manager/2026.05/Containerfile.ubuntu2404.std
+++ b/package-manager/2026.05/Containerfile.ubuntu2404.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.14.5
+RUN uv self update && uv python install 3.14.5
 RUN mv /opt/python/cpython-3.14.5-linux-*/ /opt/python/3.14.5
 
 


### PR DESCRIPTION
Applies `uv self update && uv python install` in all rendered Package Manager Containerfiles, matching the pattern introduced in posit-dev/images-shared#597.