### PR TITLE
Switch to shared checks.yml for pre-commit, zizmor, lychee

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,7 +36,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
-    uses: posit-dev/images-shared/.github/workflows/checks.yml@main
+    uses: posit-dev/images-shared/.github/workflows/checks.yml@worktree-lychee-link-checking
 
   production:
     name: Production

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,10 +16,9 @@ jobs:
     permissions: {}
     timeout-minutes: 10
     needs:
-      - lint
+      - checks
       - production
       - development
-      - zizmor
     steps:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # v1.2.2
         id: alls-green
@@ -32,22 +31,12 @@ jobs:
           result: ${{ steps.alls-green.outcome }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+  checks:
+    name: Checks
     permissions:
       contents: read
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.x"
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
-        env:
-          SKIP: no-commit-to-branch
+      security-events: write
+    uses: posit-dev/images-shared/.github/workflows/checks.yml@main
 
   production:
     name: Production
@@ -67,14 +56,3 @@ jobs:
     with:
       dev-versions: "only"
 
-  zizmor:
-    name: Zizmor
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-        with:
-          persist-credentials: false
-      - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d  # v0.5.6

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,4 +55,3 @@ jobs:
     uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
     with:
       dev-versions: "only"
-

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,4 @@
+# Hosts that rate-limit, require auth, or otherwise false-positive.
+# One regex per line (matched against each URL). Extend as real failures surface.
+https://docs.posit.co/rspm/admin/appendix/configuration.html
+https://support.posit.co

--- a/package-manager/README.md
+++ b/package-manager/README.md
@@ -217,7 +217,7 @@ Mount a custom configuration file:
 docker run -v /path/to/rstudio-pm.gcfg:/etc/rstudio-pm/rstudio-pm.gcfg ...
 ```
 
-See the [configuration documentation](https://docs.posit.co/rspm/admin/appendix/configuration/) for available options.
+See the [configuration documentation](https://docs.posit.co/rspm/admin/appendix/configuration.html) for available options.
 
 ## Healthcheck
 


### PR DESCRIPTION
Replaces the inline `lint` and `zizmor` jobs with a `checks` caller
that delegates to the shared `checks.yml` in `posit-dev/images-shared`.

Depends on:
- https://github.com/posit-dev/images-shared/pull/625

The final commit is a REVERTME that pins the workflow to the
`worktree-lychee-link-checking` branch for testing. It must be
reverted before this PR merges, once #625 is merged to main.