### PR TITLE
Expose cache input on Development workflow

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -11,6 +11,11 @@ on:
         description: "Dev channel to build (e.g. 'daily', 'preview'). When set with version, only that channel is built."
         required: false
         type: string
+      cache:
+        description: "Use the bakery registry cache. Set false to force a fresh build (e.g. when the upstream CDN .deb was replaced after a previous cached build, so the layer cache key hits the stale binary)."
+        required: false
+        type: boolean
+        default: true
 
   schedule:
     # Daily rebuild of dev images. Staggered with images-connect (08:45)
@@ -65,6 +70,10 @@ jobs:
       dev-versions: "only"
       dev-version: ${{ inputs.version }}
       dev-channel: ${{ inputs.channel }}
+      # Forward the cache input. For non-workflow_dispatch events (schedule / push),
+      # `inputs.cache` is unset, so default to true (preserves prior behavior). Only
+      # an explicit workflow_dispatch with `cache: false` disables the registry cache.
+      cache: ${{ github.event_name != 'workflow_dispatch' || inputs.cache }}
       # Push on merges to main, scheduled rebuilds, and dispatches targeting main.
       push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
 


### PR DESCRIPTION
## Summary

Adds a `cache` workflow_dispatch input on `.github/workflows/development.yml` so operators can force a fresh build that bypasses the bakery registry cache.

- New input `cache` (boolean, default `true`) exposed on `workflow_dispatch`.
- Passed through to `bakery-build-native.yml` via `cache: ${{ github.event_name != 'workflow_dispatch' || inputs.cache }}`.

The expression preserves current behavior for `schedule` and `push` (they never set `inputs.cache`, so the expression evaluates to `true`). Only an explicit `workflow_dispatch` with `cache: false` disables the cache.

## Motivation

Discovered during the PPM 2026.06.0 release. The release tag `v2026.06.0` was moved from commit `f1ed7de5c7` → `afad539fa6` to ship a metrics-cache revert (rstudio/package-manager#18609). PPM CI's `update-images` job re-dispatched this workflow with `version=2026.06.0, channel=preview`.

The new dispatch produced a new image manifest digest, but the layer-cache key for the `.deb`-install layer was unchanged (same `version` string, same CDN URL), so buildkit reused the cached layer — installing the pre-revert `.deb` into the new image. The dogfood clusters rolled onto the new digest but the running binary still reports `Build: v2026.06.0-0-gf1ed7de5c7` with `metrics_cache_version=2`, blocking the release.

Being able to set `cache: false` on the re-dispatch would have avoided the manual cache-eviction step.

## Test plan

- [ ] Dispatch the workflow with `cache: true` (default) — build behaves identically to today (cache-populated, fast).
- [ ] Dispatch the workflow with `cache: false` — the `.deb`-install and other cached layers are rebuilt from scratch.
- [ ] Merge and confirm the next scheduled/push-triggered run still uses cache (input defaults to true when unset).

## Related

- rstudio/package-manager#18552 (2026.06.0 release tracking)
- rstudio/package-manager#18609 (metrics-cache revert)
- rstudio/package-manager#18138 (2026.05.0 release retro — bakery infra gaps)