### PR TITLE
Improve layer-cache reuse across Package Manager releases

### DIFF
--- a/package-manager/2026.05/Containerfile.ubuntu2204.min
+++ b/package-manager/2026.05/Containerfile.ubuntu2204.min
@@ -3,7 +3,6 @@ LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:22.04"
 
 ### ARG declarations ###
 ARG DEBIAN_FRONTEND=noninteractive
-ARG PACKAGE_MANAGER_VERSION="2026.05.0"
 
 ENV PPM_LICENSE=""
 ENV PPM_LICENSE_SERVER=""
@@ -37,6 +36,7 @@ RUN apt-get update -yqq && \
 
 
 ### Install Package Manager 2026.05.0 ###
+ARG PACKAGE_MANAGER_VERSION="2026.05.0"
 COPY --chmod=0755 package-manager/2026.05/scripts/install_package_manager.sh /tmp/install_package_manager.sh
 RUN \
     /tmp/install_package_manager.sh \

--- a/package-manager/2026.05/Containerfile.ubuntu2204.std
+++ b/package-manager/2026.05/Containerfile.ubuntu2204.std
@@ -13,7 +13,6 @@ LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:22.04"
 
 ### ARG declarations ###
 ARG DEBIAN_FRONTEND=noninteractive
-ARG PACKAGE_MANAGER_VERSION="2026.05.0"
 
 ENV PPM_LICENSE=""
 ENV PPM_LICENSE_SERVER=""
@@ -58,6 +57,7 @@ RUN RUN_UNATTENDED=1 R_VERSION=4.6.0 bash -c "$(curl -fsSL https://rstd.io/r-ins
     find . -type f -name '[rR]-4.6.0.*\.(deb|rpm)' -delete
 
 ### Install Package Manager 2026.05.0 ###
+ARG PACKAGE_MANAGER_VERSION="2026.05.0"
 COPY --chmod=0755 package-manager/2026.05/scripts/install_package_manager.sh /tmp/install_package_manager.sh
 RUN PYTHON_VERSION=3.14.5 R_VERSION=4.6.0 \
     /tmp/install_package_manager.sh \

--- a/package-manager/2026.05/Containerfile.ubuntu2404.min
+++ b/package-manager/2026.05/Containerfile.ubuntu2404.min
@@ -4,7 +4,6 @@ LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:24.04"
 ### ARG declarations ###
 ARG TARGETARCH
 ARG DEBIAN_FRONTEND=noninteractive
-ARG PACKAGE_MANAGER_VERSION="2026.05.0"
 
 ENV PPM_LICENSE=""
 ENV PPM_LICENSE_SERVER=""
@@ -38,6 +37,7 @@ RUN apt-get update -yqq && \
 
 
 ### Install Package Manager 2026.05.0 ###
+ARG PACKAGE_MANAGER_VERSION="2026.05.0"
 COPY --chmod=0755 package-manager/2026.05/scripts/install_package_manager.sh /tmp/install_package_manager.sh
 RUN \
     /tmp/install_package_manager.sh \

--- a/package-manager/2026.05/Containerfile.ubuntu2404.std
+++ b/package-manager/2026.05/Containerfile.ubuntu2404.std
@@ -14,7 +14,6 @@ LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:24.04"
 ### ARG declarations ###
 ARG TARGETARCH
 ARG DEBIAN_FRONTEND=noninteractive
-ARG PACKAGE_MANAGER_VERSION="2026.05.0"
 
 ENV PPM_LICENSE=""
 ENV PPM_LICENSE_SERVER=""
@@ -59,6 +58,7 @@ RUN RUN_UNATTENDED=1 R_VERSION=4.6.0 bash -c "$(curl -fsSL https://rstd.io/r-ins
     find . -type f -name '[rR]-4.6.0.*\.(deb|rpm)' -delete
 
 ### Install Package Manager 2026.05.0 ###
+ARG PACKAGE_MANAGER_VERSION="2026.05.0"
 COPY --chmod=0755 package-manager/2026.05/scripts/install_package_manager.sh /tmp/install_package_manager.sh
 RUN PYTHON_VERSION=3.14.5 R_VERSION=4.6.0 \
     /tmp/install_package_manager.sh \

--- a/package-manager/template/Containerfile.ubuntu2204.jinja2
+++ b/package-manager/template/Containerfile.ubuntu2204.jinja2
@@ -17,7 +17,6 @@ LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:22.04"
 
 ### ARG declarations ###
 ARG DEBIAN_FRONTEND=noninteractive
-ARG PACKAGE_MANAGER_VERSION="{{ Image.Version }}"
 
 ENV PPM_LICENSE=""
 ENV PPM_LICENSE_SERVER=""
@@ -46,6 +45,7 @@ COPY {{ Path.Version }}/deps/python_requirements.txt /tmp/requirements.txt
 {%- endif %}
 
 ### Install Package Manager {{ Image.Version }} ###
+ARG PACKAGE_MANAGER_VERSION="{{ Image.Version }}"
 COPY --chmod=0755 {{ Path.Version }}/scripts/install_package_manager.sh /tmp/install_package_manager.sh
 RUN {% if Image.Variant != "Minimal" %}PYTHON_VERSION={{ Dependencies.python.0 }} R_VERSION={{ Dependencies.R.0 }} {% endif %}{% if Image.DownloadURL is defined %}DOWNLOAD_URL="{{ Image.DownloadURL }}" {% endif %}\
     /tmp/install_package_manager.sh \

--- a/package-manager/template/Containerfile.ubuntu2404.jinja2
+++ b/package-manager/template/Containerfile.ubuntu2404.jinja2
@@ -18,7 +18,6 @@ LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:24.04"
 ### ARG declarations ###
 ARG TARGETARCH
 ARG DEBIAN_FRONTEND=noninteractive
-ARG PACKAGE_MANAGER_VERSION="{{ Image.Version }}"
 
 ENV PPM_LICENSE=""
 ENV PPM_LICENSE_SERVER=""
@@ -47,6 +46,7 @@ COPY {{ Path.Version }}/deps/python_requirements.txt /tmp/requirements.txt
 {%- endif %}
 
 ### Install Package Manager {{ Image.Version }} ###
+ARG PACKAGE_MANAGER_VERSION="{{ Image.Version }}"
 COPY --chmod=0755 {{ Path.Version }}/scripts/install_package_manager.sh /tmp/install_package_manager.sh
 RUN {% if Image.Variant != "Minimal" %}PYTHON_VERSION={{ Dependencies.python.0 }} R_VERSION={{ Dependencies.R.0 }} {% endif %}{% if Image.DownloadURL is defined %}DOWNLOAD_URL="{{ Image.DownloadURL }}" {% endif %}\
     /tmp/install_package_manager.sh \


### PR DESCRIPTION
Every Package Manager release rebuilds apt, Python, and R, because the version `ARG` sat at the top of the Containerfile and invalidated every layer below it — none of which depend on the Package Manager version. This defeats CI's registry layer cache. Relocating the `ARG` to just before the Package Manager install lets those version-invariant layers be reused across releases. The version stays recorded via Bakery's `org.opencontainers.image.version` label.
