### PR TITLE
Restrict Production/Release dispatch to main

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -42,6 +42,17 @@ jobs:
           result: ${{ steps.alls-green.outcome }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
+  # Jobs that call a reusable workflow via `uses:` can't also set
+  # `environment:`, so the branch restriction lives in its own job and
+  # build depends on it.
+  main-only:
+    name: Main Only
+    runs-on: ubuntu-latest
+    permissions: {}
+    environment: production
+    steps:
+      - run: echo "Branch allowed by environment policy."
+
   build:
     name: Build
     # Build all images, excluding dev versions.
@@ -49,6 +60,8 @@ jobs:
     # Builds all versions of each image in parallel.
     #
     # Run on merges to main, or on weekly scheduled re-builds.
+    needs:
+      - main-only
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,20 @@ on:
 
 
 jobs:
+  # Jobs that call a reusable workflow via `uses:` can't also set
+  # `environment:`, so the branch restriction lives in its own job and
+  # release depends on it.
+  main-only:
+    name: Main Only
+    runs-on: ubuntu-latest
+    permissions: {}
+    environment: production
+    steps:
+      - run: echo "Branch allowed by environment policy."
+
   release:
+    needs:
+      - main-only
     if: github.event_name == 'workflow_dispatch'
     permissions:
       contents: write


### PR DESCRIPTION
Manually dispatching Production or Release from a non-main branch runs the full build, or for Release, opens a release PR, with no ref check — Production only skips the final push step, and Release has no guard at all.

Adds a `main-only` gate job backed by this repo's `production` GitHub environment, now restricted to the `main` branch. `build`/`release` depend on it via `needs:`, so an off-main dispatch fails immediately instead of burning CI time or mutating repo state from the wrong ref.

This lives in its own job because a job that `uses:` a reusable workflow can't also carry `environment:`.