### PR TITLE
Test images-shared PR #668 release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,25 +10,12 @@ on:
 
 
 jobs:
-  # Jobs that call a reusable workflow via `uses:` can't also set
-  # `environment:`, so the branch restriction lives in its own job and
-  # release depends on it.
-  main-only:
-    name: Main Only
-    runs-on: ubuntu-latest
-    permissions: {}
-    environment: production
-    steps:
-      - run: echo "Branch allowed by environment policy."
-
   release:
-    needs:
-      - main-only
     if: github.event_name == 'workflow_dispatch'
     permissions:
       contents: write
       pull-requests: write
-    uses: posit-dev/images-shared/.github/workflows/product-release.yml@main
+    uses: posit-dev/images-shared/.github/workflows/product-release.yml@feat/release-pr-diff-link
     with:
       version: ${{ inputs.version }}
       images: "package-manager"


### PR DESCRIPTION
Temporary branch to exercise the release workflow changes from posit-dev/images-shared#668 (version-diff PR comments) via workflow_dispatch.

Removes the main-only environment gate and points the release job at the feat/release-pr-diff-link branch instead of main.

Not intended to merge — revert or close once testing is complete.

- https://github.com/posit-dev/images-shared/pull/668