### PR TITLE
Add automatic deployment mechanism for ppm.posit.it

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -60,7 +60,7 @@ jobs:
     #
     # Builds all development versions of each image in parallel.
     #
-    # Run on merges to main, or on hourly scheduled re-builds.
+    # Run on merges to main, or on daily scheduled re-builds.
     permissions:
       contents: read
       packages: write
@@ -78,7 +78,7 @@ jobs:
       push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
 
   dogfood:
-    name: Update PPM Dogfood
+    name: Update internal PPM installs
     if: >-
       needs.dev.result == 'success' &&
       inputs.channel == 'daily' &&
@@ -106,9 +106,9 @@ jobs:
           app-id: ${{ secrets.PPM_AUTOMATION_APP_ID }}
           private-key: ${{ secrets.PPM_AUTOMATION_PEM }}
           owner: rstudio
-          repositories: helm-package-manager
+          repositories: helm-package-manager,pulumi-package-manager
 
-      - name: Dispatch to helm-package-manager
+      - name: Dispatch deploys
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           DEV_CHANNEL: ${{ inputs.channel }}
@@ -119,7 +119,14 @@ jobs:
           bakery ci matrix "${ARGS[@]}" | jq -r '.[].version' | sort -u | while read -r version; do
             tag="${version//+/-}"
             echo "Dispatching version: $tag"
+            # Legacy dogfood sites ({solo,s3,cluster}.packagemanager.posit.co).
+            # Remove once the aws-package-manager production stack is fully
+            # de-provisioned.
             gh workflow run arbitrary-deploy.yml \
               --repo rstudio/helm-package-manager \
               --field ppm-image-version="$tag"
+            # ppm.posit.it, the dogfood replacement (aws-ppm-team Pulumi stack).
+            gh workflow run aws_ppm_team_image_update.yml \
+              --repo rstudio/pulumi-package-manager \
+              --field image_tag="$tag"
           done


### PR DESCRIPTION
## Summary

The internal dogfood sites are being replaced by ppm.posit.it (the `aws-ppm-team` Pulumi stack in rstudio/pulumi-package-manager). This extends the `dogfood` job in `development.yml` so new dev images are deployed there too: it now also dispatches **PPM Image Update (aws-ppm-team)** in `rstudio/pulumi-package-manager` with the new image tag (companion PR: rstudio/pulumi-package-manager#377).

## Changes

- The PPM automation app token now also covers `pulumi-package-manager` (the app must be installed on that repo — see the companion PR's setup notes).
- The dispatch step sends the tag to both `helm-package-manager` (legacy dogfood sites — remove once the `aws-package-manager` production stack is fully de-provisioned) and `pulumi-package-manager` (ppm.posit.it).
- Renamed the job display name to "Update internal PPM installs" and fixed a stale comment ("hourly" → "daily" rebuilds, stale since the cron change in `4967d90`).

## Testing

- Workflow YAML parses. The dispatch loop is unchanged apart from the second `gh workflow run`; end-to-end behavior is exercised on the next merge to `rstudio/package-manager` main after both PRs land and the one-time app setup is done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
