### PR TITLE
Point temp-registry at ECR in build workflows

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -64,6 +64,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
 
     uses: "posit-dev/images-shared/.github/workflows/bakery-build-native.yml@main"
     secrets:

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -66,10 +66,13 @@ jobs:
       packages: write
 
     uses: "posit-dev/images-shared/.github/workflows/bakery-build-native.yml@main"
+    secrets:
+      AWS_ROLE: ${{ secrets.AWS_ROLE }}
     with:
       dev-versions: "only"
       dev-version: ${{ inputs.version }}
       dev-channel: ${{ inputs.channel }}
+      temp-registry: "565037064999.dkr.ecr.us-east-2.amazonaws.com/images"
       # Forward the cache input. For non-workflow_dispatch events (schedule / push),
       # `inputs.cache` is unset, so default to true (preserves prior behavior). Only
       # an explicit workflow_dispatch with `cache: false` disables the registry cache.

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -65,6 +65,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
 
     uses: "posit-dev/images-shared/.github/workflows/bakery-build-native.yml@main"
     secrets:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -71,8 +71,10 @@ jobs:
       DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       DOCKER_HUB_README_USERNAME: ${{ secrets.DOCKER_HUB_README_USERNAME }}
       DOCKER_HUB_README_PASSWORD: ${{ secrets.DOCKER_HUB_README_PASSWORD }}
+      AWS_ROLE: ${{ secrets.AWS_ROLE }}
     with:
       dev-versions: "exclude"
+      temp-registry: "565037064999.dkr.ecr.us-east-2.amazonaws.com/images"
       # Push images only for merges into main and weekly schduled re-builds.
       push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
 


### PR DESCRIPTION
## Summary
This change redirects temporary image storage to ECR to reduce ratelimiting strain on GHCR. There is not functional change to the build except for where builds are placed in the interim.

- Add `temp-registry: 565037064999.dkr.ecr.us-east-2.amazonaws.com/images` to the `bakery-build-native.yml` calls in `development.yml` and `production.yml`
- Forward the `AWS_ROLE` secret (already present in this repo) to each of those calls

Refs posit-dev/images-shared#682

## Test plan
- [ ] `workflow_dispatch` run of `development.yml`/`production.yml` succeeds and temp images land in the ECR repo