### PR TITLE
Skip cache restore in dogfood and update-helm jobs

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -102,6 +102,8 @@ jobs:
 
       - name: Setup bakery
         uses: posit-dev/images-shared/setup-bakery@main
+        with:
+          restore-cache: "false"
 
       - name: Generate GitHub App Token
         id: app-token

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -96,6 +96,8 @@ jobs:
 
       - name: Install bakery
         uses: posit-dev/images-shared/setup-bakery@main
+        with:
+          restore-cache: "false"
 
       - name: Get latest version
         id: version


### PR DESCRIPTION
Neither job passes cache-scope, so their dependency-version cache
artifact name never matches any writer job's -- the restore always
misses and logs a confusing "Artifact not found" error on every run.

Opt out via the new restore-cache input on setup-bakery.

Blocked on the images-shared PR below merging to main -- these
workflows pin setup-bakery@main, and composite actions reject
unrecognized inputs, so CI here will fail until that lands. Opening
as a draft for that reason.

- https://github.com/posit-dev/images-shared/pull/708
- https://github.com/posit-dev/images-shared/issues/686