### PR TITLE
Group dependabot security updates into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,7 @@ updates:
       actions:
         patterns:
           - "*"
+      actions-security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"


### PR DESCRIPTION
Dependabot's `groups` key only covers version updates by default;
security-alert PRs need an explicit `applies-to: security-updates`
group or they arrive individually, ungrouped.

Add a security sibling group to the `actions` group so a future
security alert lands as one grouped PR instead of one per
dependency.