### PR TITLE
Fix the dogfood dispatch never firing on scheduled rebuilds

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -83,9 +83,13 @@ jobs:
 
   dogfood:
     name: Update internal PPM installs
+    # `inputs` is only populated on workflow_dispatch; on schedule and push
+    # events `inputs.channel` is empty, so those events must be allowed
+    # through without the channel check (the dispatch step defaults them to
+    # the daily channel).
     if: >-
       needs.dev.result == 'success' &&
-      inputs.channel == 'daily' &&
+      (inputs.channel == 'daily' || github.event_name != 'workflow_dispatch') &&
       (github.event_name == 'push' && github.ref == 'refs/heads/main' ||
        github.event_name == 'schedule' ||
        github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
@@ -115,7 +119,9 @@ jobs:
       - name: Dispatch deploys
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          DEV_CHANNEL: ${{ inputs.channel }}
+          # Schedule and push runs build every dev channel; only the daily
+          # channel is deployed to the internal installs.
+          DEV_CHANNEL: ${{ inputs.channel || 'daily' }}
         run: |
           ARGS=(--dev-versions only --exclude platform --quiet)
           [[ -n "$DEV_CHANNEL" ]] && ARGS+=(--dev-channel "$DEV_CHANNEL")


### PR DESCRIPTION
## Problem

The `dogfood` job in `development.yml` is gated on `inputs.channel == 'daily'`, but `inputs` is only populated on `workflow_dispatch` events. On `schedule` and `push` runs `inputs.channel` is empty, so the condition was always false — the `github.event_name == 'schedule'` and `push` clauses in the event check were dead code.

In practice this means the daily 07:45 UTC rebuild has **never** dispatched a deploy to `ppm.posit.it`, contrary to the documented behavior in `rstudio/pulumi-package-manager`'s `aws-ppm-team/README.md` ("deployed on every `package-manager` merge, **plus the daily image rebuild**"). Verified empirically: every run of `aws_ppm_team_image_update.yml` to date corresponds to a `workflow_dispatch` development build; no scheduled run (e.g. 2026-08-07 08:10, run 31160580650) has ever produced one. Concretely, on Aug 7 the schedule run rebuilt the last published dev `.deb` at 08:10 but the deploy waited until a merge-triggered dispatch at 11:45.

## Fix

- Let non-`workflow_dispatch` events (schedule, push to main) through the channel gate. Manual dispatches still require `channel: daily`, so a `preview`-channel or channel-less dispatch continues to skip the job, as before.
- Default `DEV_CHANNEL` to `daily` in the dispatch step: schedule/push runs build every dev channel, and only the daily-channel version should be deployed to the internal installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)