### PR TITLE
Forward Wiz secrets to bakery-build-native.yml

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -69,6 +69,10 @@ jobs:
     uses: "posit-dev/images-shared/.github/workflows/bakery-build-native.yml@main"
     secrets:
       AWS_ROLE: ${{ secrets.AWS_ROLE }}
+      WIZ_CLIENT_ID: ${{ secrets.WIZ_CLIENT_ID }}
+      WIZ_CLIENT_SECRET: ${{ secrets.WIZ_CLIENT_SECRET }}
+      WIZ_POLICY_ID: ${{ secrets.WIZ_POLICY_ID }}
+      WIZ_PROJECT_ID: ${{ secrets.WIZ_PROJECT_ID }}
     with:
       dev-versions: "only"
       dev-version: ${{ inputs.version }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -73,6 +73,10 @@ jobs:
       DOCKER_HUB_README_USERNAME: ${{ secrets.DOCKER_HUB_README_USERNAME }}
       DOCKER_HUB_README_PASSWORD: ${{ secrets.DOCKER_HUB_README_PASSWORD }}
       AWS_ROLE: ${{ secrets.AWS_ROLE }}
+      WIZ_CLIENT_ID: ${{ secrets.WIZ_CLIENT_ID }}
+      WIZ_CLIENT_SECRET: ${{ secrets.WIZ_CLIENT_SECRET }}
+      WIZ_POLICY_ID: ${{ secrets.WIZ_POLICY_ID }}
+      WIZ_PROJECT_ID: ${{ secrets.WIZ_PROJECT_ID }}
     with:
       dev-versions: "exclude"
       temp-registry: "565037064999.dkr.ecr.us-east-2.amazonaws.com/images"


### PR DESCRIPTION
Forwards `WIZ_CLIENT_ID`, `WIZ_CLIENT_SECRET`, `WIZ_POLICY_ID`, and `WIZ_PROJECT_ID` secrets to the shared `bakery-build-native.yml` reusable workflow, enabling the advisory-only Wiz container security scan added in posit-dev/images-shared#715.

When the secrets are absent the Scan step is skipped cleanly; when present it runs `bakery wizcli scan` after each image build with `continue-on-error: true` (a policy violation is visible in the log but never blocks a build).

**Note:** Contains a `[REVERTME]` commit that points the workflow at `feat/wizcli-security-scan` in images-shared for testing. That commit must be dropped (or the ref changed back to `@main`) before merging — this PR should merge after posit-dev/images-shared#715.

Depends on: posit-dev/images-shared#715