### PR TITLE
[DNM] test: exercise Trivy scanning against images-shared#722

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -65,6 +65,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      security-events: write
 
     uses: "posit-dev/images-shared/.github/workflows/bakery-build-native.yml@main"
     secrets:

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -65,7 +65,6 @@ jobs:
       contents: read
       packages: write
       id-token: write
-      security-events: write
 
     uses: "posit-dev/images-shared/.github/workflows/bakery-build-native.yml@feat/trivy-security-scan"
     secrets:

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -67,10 +67,11 @@ jobs:
       id-token: write
       security-events: write
 
-    uses: "posit-dev/images-shared/.github/workflows/bakery-build-native.yml@main"
+    uses: "posit-dev/images-shared/.github/workflows/bakery-build-native.yml@feat/trivy-security-scan"
     secrets:
       AWS_ROLE: ${{ secrets.AWS_ROLE }}
     with:
+      version: feat/trivy-security-scan
       dev-versions: "only"
       dev-version: ${{ inputs.version }}
       dev-channel: ${{ inputs.channel }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,8 +55,9 @@ jobs:
       contents: read
       packages: write
       security-events: write
-    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
+    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@feat/trivy-security-scan
     with:
+      version: feat/trivy-security-scan
       dev-versions: "exclude"
 
   development:
@@ -65,8 +66,9 @@ jobs:
       contents: read
       packages: write
       security-events: write
-    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
+    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@feat/trivy-security-scan
     with:
+      version: feat/trivy-security-scan
       dev-versions: "only"
 
   zizmor:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -54,7 +54,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      security-events: write
     uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@feat/trivy-security-scan
     with:
       version: feat/trivy-security-scan
@@ -65,7 +64,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      security-events: write
     uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@feat/trivy-security-scan
     with:
       version: feat/trivy-security-scan

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -54,6 +54,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      security-events: write
     uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
     with:
       dev-versions: "exclude"
@@ -63,6 +64,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      security-events: write
     uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
     with:
       dev-versions: "only"

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -66,6 +66,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      security-events: write
 
     uses: "posit-dev/images-shared/.github/workflows/bakery-build-native.yml@main"
     secrets:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -68,13 +68,14 @@ jobs:
       id-token: write
       security-events: write
 
-    uses: "posit-dev/images-shared/.github/workflows/bakery-build-native.yml@main"
+    uses: "posit-dev/images-shared/.github/workflows/bakery-build-native.yml@feat/trivy-security-scan"
     secrets:
       DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       DOCKER_HUB_README_USERNAME: ${{ secrets.DOCKER_HUB_README_USERNAME }}
       DOCKER_HUB_README_PASSWORD: ${{ secrets.DOCKER_HUB_README_PASSWORD }}
       AWS_ROLE: ${{ secrets.AWS_ROLE }}
     with:
+      version: feat/trivy-security-scan
       dev-versions: "exclude"
       temp-registry: "565037064999.dkr.ecr.us-east-2.amazonaws.com/images"
       # Push images only for merges into main and weekly schduled re-builds.

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -66,7 +66,6 @@ jobs:
       contents: read
       packages: write
       id-token: write
-      security-events: write
 
     uses: "posit-dev/images-shared/.github/workflows/bakery-build-native.yml@feat/trivy-security-scan"
     secrets:


### PR DESCRIPTION
Test-only. Points package-manager's three build workflows at `images-shared`'s `feat/trivy-security-scan` so images-shared#722's Trivy scanning runs against real package-manager builds before it merges.

Nothing here is mergeable — PR scanning needs no caller-side change, since the `Scan` step is ungated in the shared reusable workflows. `security-events: write` grants were removed; they belong to the code-scanning upload in images-shared#734 and will land in a separate follow-up sequenced by images-shared#729.

- https://github.com/posit-dev/images-shared/pull/722
