### PR TITLE
TEST: Validate images-shared build summary reporting (do not merge)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -54,18 +54,24 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
+    # TEMPORARY: pointed at feat/actions-job-summary to test the new build
+    # summary reporting end-to-end. Revert to @main before merging.
+    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@feat/actions-job-summary
     with:
       dev-versions: "exclude"
+      version: "feat/actions-job-summary"
 
   development:
     name: Development
     permissions:
       contents: read
       packages: write
-    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
+    # TEMPORARY: pointed at feat/actions-job-summary to test the new build
+    # summary reporting end-to-end. Revert to @main before merging.
+    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@feat/actions-job-summary
     with:
       dev-versions: "only"
+      version: "feat/actions-job-summary"
 
   zizmor:
     name: Zizmor


### PR DESCRIPTION
Temporary PR to validate the CI build summary reporting added in posit-dev/images-shared`feat/actions-job-summary`. Points `pr.yml`'s `bakery-build-pr.yml` calls at that branch (workflow ref and bakery CLI version) instead of `@main`.

Not for merging — revert `.github/workflows/pr.yml` to `@main` or close this PR once the run summary has been verified in the Actions tab.